### PR TITLE
Add ERC-20 reserve

### DIFF
--- a/src/Dai.sol
+++ b/src/Dai.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+
+interface IDai is IERC20 {
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}

--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -2,20 +2,8 @@
 pragma solidity ^0.8.7;
 
 import {ERC20DripsHub, DripsReceiver, SplitsReceiver} from "./ERC20DripsHub.sol";
-import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
-
-interface IDai is IERC20 {
-    function permit(
-        address holder,
-        address spender,
-        uint256 nonce,
-        uint256 expiry,
-        bool allowed,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
-}
+import {IDai} from "./Dai.sol";
+import {IDaiReserve} from "./DaiReserve.sol";
 
 struct PermitArgs {
     uint256 nonce;
@@ -36,9 +24,9 @@ contract DaiDripsHub is ERC20DripsHub {
     constructor(
         uint64 cycleSecs,
         address owner,
-        IDai _dai
-    ) ERC20DripsHub(cycleSecs, owner, _dai) {
-        dai = _dai;
+        IDaiReserve reserve
+    ) ERC20DripsHub(cycleSecs, owner, reserve) {
+        dai = reserve.dai();
     }
 
     /// @notice Sets the drips configuration of the `msg.sender`

--- a/src/DaiReserve.sol
+++ b/src/DaiReserve.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import {ERC20Reserve, IERC20Reserve} from "./ERC20Reserve.sol";
+import {IDai} from "./Dai.sol";
+
+interface IDaiReserve is IERC20Reserve {
+    function dai() external view returns (IDai);
+}
+
+contract DaiReserve is ERC20Reserve, IDaiReserve {
+    IDai public immutable override dai;
+
+    constructor(
+        IDai _dai,
+        address owner,
+        address user
+    ) ERC20Reserve(_dai, owner, user) {
+        dai = _dai;
+    }
+}

--- a/src/ERC20Reserve.sol
+++ b/src/ERC20Reserve.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+
+interface IERC20Reserve {
+    function erc20() external view returns (IERC20);
+
+    function withdraw(uint256 amt) external;
+
+    function deposit(uint256 amt) external;
+}
+
+contract ERC20Reserve is IERC20Reserve, Ownable {
+    IERC20 public immutable override erc20;
+    address public user;
+    uint256 public balance;
+
+    event Withdrawn(address to, uint256 amt);
+    event Deposited(address from, uint256 amt);
+    event ForceWithdrawn(address to, uint256 amt);
+    event UserSet(address oldUser, address newUser);
+
+    constructor(
+        IERC20 _erc20,
+        address owner,
+        address _user
+    ) {
+        erc20 = _erc20;
+        transferOwnership(owner);
+        setUser(_user);
+    }
+
+    modifier onlyUser() {
+        require(_msgSender() == user, "Reserve: caller is not the user");
+        _;
+    }
+
+    function withdraw(uint256 amt) public override onlyUser {
+        require(balance >= amt, "Reserve: withdrawal over balance");
+        balance -= amt;
+        emit Withdrawn(_msgSender(), amt);
+        require(erc20.transfer(_msgSender(), amt), "Reserve: transfer failed");
+    }
+
+    function deposit(uint256 amt) public override onlyUser {
+        balance += amt;
+        emit Deposited(_msgSender(), amt);
+        require(erc20.transferFrom(_msgSender(), address(this), amt), "Reserve: transfer failed");
+    }
+
+    function forceWithdraw(uint256 amt) public onlyOwner {
+        emit ForceWithdrawn(_msgSender(), amt);
+        require(erc20.transfer(_msgSender(), amt), "Reserve: transfer failed");
+    }
+
+    function setUser(address newUser) public onlyOwner {
+        emit UserSet(user, newUser);
+        user = newUser;
+    }
+}

--- a/src/test/ERC20DripsHub.t.sol
+++ b/src/test/ERC20DripsHub.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.7;
 
 import {DripsHubUser, ERC20DripsHubUser} from "./DripsHubUser.t.sol";
 import {DripsHubTest} from "./EthDripsHub.t.sol";
+import {ERC20Reserve, IERC20Reserve} from "../ERC20Reserve.sol";
 import {ERC20DripsHub} from "../ERC20DripsHub.sol";
 import {IERC20, ERC20PresetFixedSupply} from "openzeppelin-contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
@@ -11,7 +12,9 @@ contract ERC20DripsHubTest is DripsHubTest {
 
     function setUp() public {
         IERC20 erc20 = new ERC20PresetFixedSupply("test", "test", 10**6 * 1 ether, address(this));
-        dripsHub = new ERC20DripsHub(10, address(this), erc20);
+        ERC20Reserve reserve = new ERC20Reserve(erc20, address(this), address(0));
+        dripsHub = new ERC20DripsHub(10, address(this), reserve);
+        reserve.setUser(address(dripsHub));
         setUp(dripsHub);
     }
 

--- a/src/test/TestDai.sol
+++ b/src/test/TestDai.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
-
 pragma solidity ^0.8.7;
 
-import "openzeppelin-contracts/token/ERC20/ERC20.sol";
-import {IDai} from "../DaiDripsHub.sol";
+import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import {IDai} from "../Dai.sol";
 
 contract Dai is ERC20, IDai {
     bytes32 private immutable domainSeparator;


### PR DESCRIPTION
Closes https://github.com/radicle-dev/radicle-drips-hub/issues/56.

It may make sense to require that the user of the hub approves spending of ERC-20 not by the hub itself, but by `hub.reserve()`. It'd save us an unnecessary transfer, but it could be weirder for the users of the hub.