### PR TITLE
Add DripsHub proxy

### DIFF
--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -13,7 +13,7 @@ struct PermitArgs {
     bytes32 s;
 }
 
-/// @notice Drips hub contract for DAI token.
+/// @notice Drips hub contract for DAI token. Must be used via a proxy.
 /// See the base `DripsHub` contract docs for more details.
 contract DaiDripsHub is ERC20DripsHub {
     /// @notice The address of the Dai contract which tokens the drips hub works with.
@@ -21,12 +21,8 @@ contract DaiDripsHub is ERC20DripsHub {
     IDai public immutable dai;
 
     /// @notice See `ERC20DripsHub` constructor documentation for more details.
-    constructor(
-        uint64 cycleSecs,
-        address owner,
-        IDaiReserve reserve
-    ) ERC20DripsHub(cycleSecs, owner, reserve) {
-        dai = reserve.dai();
+    constructor(uint64 cycleSecs, IDai _dai) ERC20DripsHub(cycleSecs, _dai) {
+        dai = _dai;
     }
 
     /// @notice Sets the drips configuration of the `msg.sender`

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {SplitsReceiver, DripsHub, DripsReceiver} from "./DripsHub.sol";
+import {SplitsReceiver, DripsReceiver} from "./DripsHub.sol";
+import {ManagedDripsHub} from "./ManagedDripsHub.sol";
 import {IERC20Reserve} from "./ERC20Reserve.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
-/// @notice Drips hub contract for any ERC-20 token.
-/// See the base `DripsHub` contract docs for more details.
-contract ERC20DripsHub is DripsHub {
+/// @notice Drips hub contract for any ERC-20 token. Must be used via a proxy.
+/// See the base `DripsHub` and `ManagedDripsHub` contract docs for more details.
+contract ERC20DripsHub is ManagedDripsHub {
     /// @notice The address of the ERC-20 contract which tokens the drips hub works with
     IERC20 public immutable erc20;
     /// @notice The address of the reserve to store funds
@@ -20,18 +21,9 @@ contract ERC20DripsHub is DripsHub {
     /// Low value makes funds more available by shortening the average time of funds being frozen
     /// between being taken from the users' drips balances and being collectable by their receivers.
     /// High value makes collecting cheaper by making it process less cycles for a given time range.
-    /// @param owner The initial owner of the contract with managerial abilities.
-    /// @param _reserve The address of the funds reserve to be used.
-    /// The drips hub will work with the ERC-20 token of the reserve.
-    /// The supply of the tokens must be lower than `2 ^ 127`.
-    constructor(
-        uint64 cycleSecs,
-        address owner,
-        IERC20Reserve _reserve
-    ) DripsHub(cycleSecs, owner) {
-        IERC20 _erc20 = _reserve.erc20();
+    /// @param _erc20 The address of an ERC-20 contract which tokens the drips hub will work with.
+    constructor(uint64 cycleSecs, IERC20 _erc20) ManagedDripsHub(cycleSecs) {
         erc20 = _erc20;
-        _setReserve(_erc20, _reserve);
     }
 
     /// @notice Sets the drips configuration of the `msg.sender`.
@@ -134,16 +126,12 @@ contract ERC20DripsHub is DripsHub {
 
     /// @notice Set the new reserve address.
     /// @param newReserve The new reserve.
-    function setReserve(IERC20Reserve newReserve) public onlyOwner {
+    function setReserve(IERC20Reserve newReserve) public onlyAdmin {
         require(newReserve.erc20() == erc20, "Invalid reserve ERC-20 address");
-        erc20.approve(address(reserve), 0);
-        _setReserve(erc20, newReserve);
-    }
-
-    function _setReserve(IERC20 _erc20, IERC20Reserve newReserve) internal {
         IERC20Reserve oldReserve = reserve;
+        if (address(oldReserve) != address(0)) erc20.approve(address(oldReserve), 0);
         reserve = newReserve;
-        _erc20.approve(address(newReserve), type(uint256).max);
+        erc20.approve(address(newReserve), type(uint256).max);
         emit ReserveSet(oldReserve, newReserve);
     }
 

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {SplitsReceiver, DripsHub, DripsReceiver} from "./DripsHub.sol";
+import {SplitsReceiver, DripsReceiver} from "./DripsHub.sol";
+import {ManagedDripsHub} from "./ManagedDripsHub.sol";
 
-/// @notice Drips hub contract for Ether.
+/// @notice Drips hub contract for Ether. Must be used via a proxy.
 /// See the base `DripsHub` contract docs for more details.
-contract EthDripsHub is DripsHub {
+contract EthDripsHub is ManagedDripsHub {
     /// @param cycleSecs The length of cycleSecs to be used in the contract instance.
     /// Low value makes funds more available by shortening the average time of funds being frozen
     /// between being taken from the users' drips balances and being collectable by their receivers.
     /// High value makes collecting cheaper by making it process less cycles for a given time range.
-    /// @param owner The initial owner of the contract with managerial abilities.
-    constructor(uint64 cycleSecs, address owner) DripsHub(cycleSecs, owner) {
+    constructor(uint64 cycleSecs) ManagedDripsHub(cycleSecs) {
         return;
     }
 

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC1967Upgrade} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Upgrade.sol";
+import {StorageSlot} from "openzeppelin-contracts/utils/StorageSlot.sol";
+import {DripsHub, SplitsReceiver} from "./DripsHub.sol";
+
+/// @notice The DripsHub which is UUPS-upgradable, pausable and has an admin.
+/// It can't be used directly, only via a proxy.
+///
+/// ManagedDripsHub uses the ERC-1967 admin slot to store the admin address.
+/// All instances of the contracts are owned by address `0x00`.
+/// While this contract is capable of updating the admin,
+/// the proxy is expected to set up the initial value of the ERC-1967 admin.
+///
+/// All instances of the contracts are paused and can't be unpaused.
+/// When a proxy uses such contract via delegation, it's initially unpaused.
+abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
+    /// @notice The ERC-1967 storage slot for the contract.
+    /// It holds a single boolean indicating if the contract is paused.
+    bytes32 private constant SLOT_PAUSED =
+        bytes32(uint256(keccak256("eip1967.managedDripsHub.paused")) - 1);
+
+    /// @notice Emitted when the pause is triggered.
+    /// @param account The account which triggered the change.
+    event Paused(address account);
+
+    /// @notice Emitted when the pause is lifted.
+    /// @param account The account which triggered the change.
+    event Unpaused(address account);
+
+    /// @notice Initializes the contract in paused state and with no admin.
+    /// The contract instance can be used only as a call delegation target for a proxy.
+    /// @param cycleSecs The length of cycleSecs to be used in the contract instance.
+    /// Low value makes funds more available by shortening the average time of funds being frozen
+    /// between being taken from the users' drips balances and being collectable by their receivers.
+    /// High value makes collecting cheaper by making it process less cycles for a given time range.
+    constructor(uint64 cycleSecs) DripsHub(cycleSecs) {
+        _pausedSlot().value = true;
+    }
+
+    /// @notice Collects all received funds available for the user
+    /// and transfers them out of the drips hub contract to that user's wallet.
+    /// @param user The user
+    /// @param currReceivers The list of the user's current splits receivers.
+    /// @return collected The collected amount
+    /// @return split The amount split to the user's splits receivers
+    function collect(address user, SplitsReceiver[] memory currReceivers)
+        public
+        override
+        whenNotPaused
+        returns (uint128 collected, uint128 split)
+    {
+        return super.collect(user, currReceivers);
+    }
+
+    /// @notice Flushes uncollected cycles of the user.
+    /// Flushed cycles won't need to be analyzed when the user collects from them.
+    /// Calling this function does not collect and does not affect the collectable amount.
+    ///
+    /// This function is needed when collecting funds received over a period so long, that the gas
+    /// needed for analyzing all the uncollected cycles can't fit in a single transaction.
+    /// Calling this function allows spreading the analysis cost over multiple transactions.
+    /// A cycle is never flushed more than once, even if this function is called many times.
+    /// @param user The user
+    /// @param maxCycles The maximum number of flushed cycles.
+    /// If too low, flushing will be cheap, but will cut little gas from the next collection.
+    /// If too high, flushing may become too expensive to fit in a single transaction.
+    /// @return flushable The number of cycles which can be flushed
+    function flushCycles(address user, uint64 maxCycles)
+        public
+        override
+        whenNotPaused
+        returns (uint64 flushable)
+    {
+        return super.flushCycles(user, maxCycles);
+    }
+
+    /// @notice Authorizes the contract upgrade. See `UUPSUpgradable` docs for more details.
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
+        newImplementation;
+    }
+
+    /// @notice Returns the address of the current admin.
+    function admin() public view returns (address) {
+        return _getAdmin();
+    }
+
+    /// @notice Changes the admin of the contract.
+    /// Can only be called by the current admin.
+    function changeAdmin(address newAdmin) public onlyAdmin {
+        _changeAdmin(newAdmin);
+    }
+
+    /// @notice Throws if called by any account other than the admin.
+    modifier onlyAdmin() {
+        require(admin() == msg.sender, "Caller is not the admin");
+        _;
+    }
+
+    /// @notice Returns true if the contract is paused, and false otherwise.
+    function paused() public view returns (bool isPaused) {
+        return _pausedSlot().value;
+    }
+
+    /// @notice Triggers stopped state.
+    function pause() public whenNotPaused onlyAdmin {
+        _pausedSlot().value = true;
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Returns to normal state.
+    function unpause() public whenPaused onlyAdmin {
+        _pausedSlot().value = false;
+        emit Unpaused(msg.sender);
+    }
+
+    /// @notice Modifier to make a function callable only when the contract is not paused.
+    modifier whenNotPaused() {
+        require(!paused(), "Contract paused");
+        _;
+    }
+
+    /// @notice Modifier to make a function callable only when the contract is paused.
+    modifier whenPaused() {
+        require(paused(), "Contract not paused");
+        _;
+    }
+
+    /// @notice Gets the storage slot holding the paused flag.
+    function _pausedSlot() private pure returns (StorageSlot.BooleanSlot storage) {
+        return StorageSlot.getBooleanSlot(SLOT_PAUSED);
+    }
+}
+
+/// @notice A generic ManagedDripsHub proxy.
+contract ManagedDripsHubProxy is ERC1967Proxy {
+    constructor(ManagedDripsHub hubLogic, address admin)
+        ERC1967Proxy(address(hubLogic), new bytes(0))
+    {
+        _changeAdmin(admin);
+    }
+}

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.7;
 
-import {EthDripsHub, DripsHub} from "../EthDripsHub.sol";
+import {DripsHub} from "../DripsHub.sol";
+import {EthDripsHub} from "../EthDripsHub.sol";
 import {SplitsReceiver, ERC20DripsHub, DripsReceiver} from "../ERC20DripsHub.sol";
 
 abstract contract DripsHubUser {
@@ -164,8 +165,9 @@ contract EthDripsHubUser is DripsHubUser {
         dripsHub = dripsHub_;
     }
 
-    // solhint-disable-next-line no-empty-blocks
-    receive() external payable {}
+    receive() external payable {
+        return;
+    }
 
     function getDripsHub() internal view override returns (DripsHub) {
         return DripsHub(dripsHub);

--- a/src/test/ERC20DripsHub.t.sol
+++ b/src/test/ERC20DripsHub.t.sol
@@ -5,16 +5,20 @@ import {DripsHubUser, ERC20DripsHubUser} from "./DripsHubUser.t.sol";
 import {DripsHubTest} from "./EthDripsHub.t.sol";
 import {ERC20Reserve, IERC20Reserve} from "../ERC20Reserve.sol";
 import {ERC20DripsHub} from "../ERC20DripsHub.sol";
+import {ManagedDripsHubProxy} from "../ManagedDripsHub.sol";
 import {IERC20, ERC20PresetFixedSupply} from "openzeppelin-contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
 contract ERC20DripsHubTest is DripsHubTest {
     ERC20DripsHub private dripsHub;
 
     function setUp() public {
-        IERC20 erc20 = new ERC20PresetFixedSupply("test", "test", 10**6 * 1 ether, address(this));
-        ERC20Reserve reserve = new ERC20Reserve(erc20, address(this), address(0));
-        dripsHub = new ERC20DripsHub(10, address(this), reserve);
-        reserve.setUser(address(dripsHub));
+        address owner = address(this);
+        IERC20 erc20 = new ERC20PresetFixedSupply("test", "test", 10**6 * 1 ether, owner);
+        ERC20DripsHub hubLogic = new ERC20DripsHub(10, erc20);
+        ManagedDripsHubProxy proxy = new ManagedDripsHubProxy(hubLogic, owner);
+        dripsHub = ERC20DripsHub(address(proxy));
+        ERC20Reserve reserve = new ERC20Reserve(erc20, owner, address(dripsHub));
+        dripsHub.setReserve(reserve);
         setUp(dripsHub);
     }
 

--- a/src/test/EthDripsHub.t.sol
+++ b/src/test/EthDripsHub.t.sol
@@ -4,12 +4,16 @@ pragma solidity ^0.8.7;
 import {DripsHubUser, EthDripsHubUser} from "./DripsHubUser.t.sol";
 import {DripsHubTest} from "./DripsHub.t.sol";
 import {EthDripsHub} from "../EthDripsHub.sol";
+import {ManagedDripsHubProxy} from "../ManagedDripsHub.sol";
 
 contract EthDripsHubTest is DripsHubTest {
     EthDripsHub private dripsHub;
 
     function setUp() public {
-        dripsHub = new EthDripsHub(10, address(this));
+        EthDripsHub hubLogic = new EthDripsHub(10);
+        address owner = address(this);
+        ManagedDripsHubProxy proxy = new ManagedDripsHubProxy(hubLogic, owner);
+        dripsHub = EthDripsHub(address(proxy));
         setUp(dripsHub);
     }
 


### PR DESCRIPTION
It puts all DripsHubs behind a proxy making them upgradable using the UUPS pattern.

Moves the owner and paused state to the unstructured storage. To do that the PR adds new mixins. The next PR #74 moves the rest of the DripsHub storage to unstructured storage. This way any upgrades in any part of the inheritance tree can be done atomically and without affecting the storage layout.