### PR TITLE
Add ens support

### DIFF
--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -92,11 +92,11 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     /// @param hash The ENS name hash.
     /// @return owner Address that the ens name points to.
     function _getENSAddress(string memory hash) internal view returns (address owner) {
-	Resolver resolver = ens.resolver(hash);
-	owner = resolver.addr(hash);
-	require(owner != address(0), "Owner not set or ens name set to burn")
+        Resolver resolver = ens.resolver(hash);
+        owner = resolver.addr(hash);
+        require(owner != address(0), "Owner not set or ens name set to burn")
 
-	return owner;
+        return owner;
     }
 
     /// @notice Authorizes the contract upgrade. See `UUPSUpgradable` docs for more details.


### PR DESCRIPTION
This pr is a proposal to add ens name support.
There are a few things that I would like to get feedback on before I continue.

1. Currently `_getENSAdress` is declared in the `ManagedDripsHub` contract. Should it stay there or might it be better to move it to the `DripsHub` contract?
2. My initial thought is to use function overloading in order to enable passing an ens name hash to every function that would normally accept an address. However this would add a lot of functions that only differentiate by one parameter and a call to `_getENSAddress`. Is there a better way? Maybe we pass addresses as strings and then add a function that evaluates whether the passed string is an address or an ens name hash. Alternatively we could implement an authentication module and use that in front of all relevant functions.