### PR TITLE
Make reserve immutable in hub

### DIFF
--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {ERC20DripsHub, DripsReceiver, SplitsReceiver} from "./ERC20DripsHub.sol";
+import {ERC20DripsHub, DripsReceiver, IERC20Reserve, SplitsReceiver} from "./ERC20DripsHub.sol";
 import {IDai} from "./IDai.sol";
-import {IDaiReserve} from "./DaiReserve.sol";
 
 struct PermitArgs {
     uint256 nonce;
@@ -21,7 +20,11 @@ contract DaiDripsHub is ERC20DripsHub {
     IDai public immutable dai;
 
     /// @notice See `ERC20DripsHub` constructor documentation for more details.
-    constructor(uint64 cycleSecs, IDai _dai) ERC20DripsHub(cycleSecs, _dai) {
+    constructor(
+        uint64 cycleSecs,
+        IDai _dai,
+        IERC20Reserve reserve
+    ) ERC20DripsHub(cycleSecs, _dai, reserve) {
         dai = _dai;
     }
 

--- a/src/test/ERC20DripsHub.t.sol
+++ b/src/test/ERC20DripsHub.t.sol
@@ -13,10 +13,10 @@ contract ERC20DripsHubTest is ManagedDripsHubTest {
 
     function setUp() public {
         IERC20 erc20 = new ERC20PresetFixedSupply("test", "test", 10**6 * 1 ether, address(this));
-        ERC20DripsHub hubLogic = new ERC20DripsHub(10, erc20);
+        ERC20Reserve reserve = new ERC20Reserve(erc20, address(this), address(0));
+        ERC20DripsHub hubLogic = new ERC20DripsHub(10, erc20, reserve);
         dripsHub = ERC20DripsHub(address(wrapInProxy(hubLogic)));
-        ERC20Reserve reserve = new ERC20Reserve(erc20, address(this), address(dripsHub));
-        dripsHub.setReserve(reserve);
+        reserve.setUser(address(dripsHub));
         ManagedDripsHubTest.setUp(dripsHub);
     }
 
@@ -27,7 +27,11 @@ contract ERC20DripsHubTest is ManagedDripsHubTest {
 
     function testContractCanBeUpgraded() public override {
         uint64 newCycleLength = dripsHub.cycleSecs() + 1;
-        ERC20DripsHub newLogic = new ERC20DripsHub(newCycleLength, dripsHub.erc20());
+        ERC20DripsHub newLogic = new ERC20DripsHub(
+            newCycleLength,
+            dripsHub.erc20(),
+            dripsHub.reserve()
+        );
         admin.upgradeTo(address(newLogic));
         assertEq(dripsHub.cycleSecs(), newCycleLength, "Invalid new cycle length");
     }


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/95.

The reserve doesn't need to be changeable on the drips hub side. With the introduction of the multi-token reserve it'll be not only unnecessary but also virtually impossible. The logic without the reserve setter is simpler and safer, also the gas cost for the users is lower because there are fewer storage accesses. This PR doesn't prevent the immutable variable from being changed with a logic upgrade.

CC: [deckardkrug](https://github.com/deckardkrug)