### PR TITLE
feat: storage functions in assembly

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -698,7 +698,7 @@ abstract contract DripsHub {
                 mstore(0x20, add(sp, 2)) // 2: position of accountsDripsHash in struct
                 mstore(0x00, user)
                 let userp := keccak256(0x00, 0x40)
-                mstore(0x00, account) // position account
+                mstore(0x00, account)
                 mstore(0x20, userp)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
             }

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -692,7 +692,8 @@ abstract contract DripsHub {
         address user = userOrAccount.user;
         if (userOrAccount.isAccount) {
             // in assembly => _storage().accountDripsHashes[userOrAccount.user][userOrAccount.account] = newDripsHash;
-            uint account = userOrAccount.account;
+            uint256 account = userOrAccount.account;
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 mstore(0x20, add(sp, 2)) // 2: position of accountsDripsHash in struct
                 mstore(0x00, user)
@@ -700,15 +701,16 @@ abstract contract DripsHub {
                 mstore(0x00, account) // position account
                 mstore(0x20, userp)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
-            }            
+            }
         } else {
             // in assembly => _storage().userDripsHashes[userOrAccount.user] = newDripsHash;
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 mstore(0x20, add(sp, 1)) // 1: position of userDripsHashes in struct
                 mstore(0x00, user)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
             }
-        } 
+        }
     }
 
     /// @notice Calculates the hash of the drips configuration.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -692,25 +692,23 @@ abstract contract DripsHub {
         address user = userOrAccount.user;
         if (userOrAccount.isAccount) {
             // in assembly => _storage().accountDripsHashes[userOrAccount.user][userOrAccount.account] = newDripsHash;
-            uint256 account = userOrAccount.account;
+            uint account = userOrAccount.account;
             assembly {
-                // 2 is the position in the SLOT Storage Struct of the accountDripsHashes
-                mstore(0x20, add(sp, 2))
+                mstore(0x20, add(sp, 2)) // 2: position of accountsDripsHash in struct
                 mstore(0x00, user)
-                let p := keccak256(0x00, 0x40)
-                mstore(0x00, account)
-                mstore(0x20, p)
+                let userp := keccak256(0x00, 0x40)
+                mstore(0x00, account) // position account
+                mstore(0x20, userp)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
-            }
+            }            
         } else {
             // in assembly => _storage().userDripsHashes[userOrAccount.user] = newDripsHash;
             assembly {
-                // 1 is the position in the SLOT Storage Struct of the userDripsHashes
-                mstore(0x20, add(sp, 1))
+                mstore(0x20, add(sp, 1)) // 1: position of userDripsHashes in struct
                 mstore(0x00, user)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
             }
-        }
+        } 
     }
 
     /// @notice Calculates the hash of the drips configuration.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -697,9 +697,8 @@ abstract contract DripsHub {
             assembly {
                 mstore(0x20, add(sp, 2)) // 2: position of accountsDripsHash in struct
                 mstore(0x00, user)
-                let userp := keccak256(0x00, 0x40)
+                mstore(0x20, keccak256(0x00, 0x40))
                 mstore(0x00, account)
-                mstore(0x20, userp)
                 sstore(keccak256(0x00, 0x40), newDripsHash)
             }
         } else {


### PR DESCRIPTION
I was curious how much gas we can safe, if we perform the storage operations directly in assembly.

The changes are not that big but actually a tiny bit cheaper.
I think you could also optimize this further with directly accessing the  `userOrAccount` in memory.

Might be interesting for the delta storage operations but I think there would also have to do some bit manipulation for the `uint128` shared slots.

Docs: https://docs.soliditylang.org/en/v0.8.11/internals/layout_in_storage.html?highlight=storage

