### PR TITLE
Almost multi-token DripsHub

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -738,27 +738,16 @@ abstract contract DripsHub {
         return keccak256(abi.encode(receivers, update, balance));
     }
 
-    /// @notice Collects funds received by the user and sets their splits.
-    /// The collected funds are split according to `currReceivers`.
+    /// @notice Sets user splits configuration.
     /// @param user The user
-    /// @param currReceivers The list of the user's splits receivers which is currently in use.
-    /// If this function is called for the first time for the user, should be an empty array.
-    /// @param newReceivers The new list of the user's splits receivers.
+    /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    /// @return collected The collected amount
-    /// @return split The amount split to the user's splits receivers
-    function _setSplits(
-        address user,
-        SplitsReceiver[] memory currReceivers,
-        SplitsReceiver[] memory newReceivers
-    ) internal returns (uint128 collected, uint128 split) {
-        (collected, split) = _collectInternal(user, currReceivers);
-        _assertSplitsValid(newReceivers);
-        _dripsHubStorage().splitsStates[calcUserId(user)].splitsHash = hashSplits(newReceivers);
-        emit SplitsUpdated(user, newReceivers);
-        _transfer(user, int128(collected));
+    function _setSplits(address user, SplitsReceiver[] memory receivers) internal {
+        _assertSplitsValid(receivers);
+        _dripsHubStorage().splitsStates[calcUserId(user)].splitsHash = hashSplits(receivers);
+        emit SplitsUpdated(user, receivers);
     }
 
     /// @notice Validates a list of splits receivers

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -110,22 +110,13 @@ contract ERC20DripsHub is ManagedDripsHub {
         _give(_userOrAccount(msg.sender, account), receiver, amt);
     }
 
-    /// @notice Collects funds received by the `msg.sender` and sets their splits.
-    /// The collected funds are split according to `currReceivers`.
-    /// @param currReceivers The list of the user's splits receivers which is currently in use.
-    /// If this function is called for the first time for the user, should be an empty array.
-    /// @param newReceivers The new list of the user's splits receivers.
+    /// @notice Sets user splits configuration.
+    /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    /// @return collected The collected amount
-    /// @return split The amount split to the user's splits receivers
-    function setSplits(SplitsReceiver[] memory currReceivers, SplitsReceiver[] memory newReceivers)
-        public
-        whenNotPaused
-        returns (uint128 collected, uint128 split)
-    {
-        return _setSplits(msg.sender, currReceivers, newReceivers);
+    function setSplits(SplitsReceiver[] memory receivers) public whenNotPaused {
+        _setSplits(msg.sender, receivers);
     }
 
     function _transfer(address user, int128 amt) internal override {

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -98,22 +98,13 @@ contract EthDripsHub is ManagedDripsHub {
         _give(_userOrAccount(msg.sender, account), receiver, uint128(msg.value));
     }
 
-    /// @notice Collects funds received by the `msg.sender` and sets their splits.
-    /// The collected funds are split according to `currReceivers`.
-    /// @param currReceivers The list of the user's splits receivers which is currently in use.
-    /// If this function is called for the first time for the user, should be an empty array.
-    /// @param newReceivers The new list of the user's splits receivers.
+    /// @notice Sets user splits configuration.
+    /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    /// @return collected The collected amount
-    /// @return split The amount split to the user's splits receivers
-    function setSplits(SplitsReceiver[] memory currReceivers, SplitsReceiver[] memory newReceivers)
-        public
-        whenNotPaused
-        returns (uint128 collected, uint128 split)
-    {
-        return _setSplits(msg.sender, currReceivers, newReceivers);
+    function setSplits(SplitsReceiver[] memory receivers) public whenNotPaused {
+        _setSplits(msg.sender, receivers);
     }
 
     function _transfer(address user, int128 amt) internal override {

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -41,10 +41,7 @@ abstract contract DripsHubUser {
         uint128 amt
     ) public virtual;
 
-    function setSplits(
-        SplitsReceiver[] calldata currReceivers,
-        SplitsReceiver[] calldata newReceivers
-    ) public virtual returns (uint128 collected, uint128 split);
+    function setSplits(SplitsReceiver[] calldata receivers) public virtual;
 
     function collect(address receiver, SplitsReceiver[] calldata currReceivers)
         public
@@ -183,11 +180,8 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
         dripsHub.give(account, receiver, amt);
     }
 
-    function setSplits(
-        SplitsReceiver[] calldata currReceivers,
-        SplitsReceiver[] calldata newReceivers
-    ) public override returns (uint128 collected, uint128 split) {
-        return dripsHub.setSplits(currReceivers, newReceivers);
+    function setSplits(SplitsReceiver[] calldata receivers) public override {
+        dripsHub.setSplits(receivers);
     }
 }
 
@@ -258,10 +252,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
         dripsHub.give{value: amt}(account, receiver);
     }
 
-    function setSplits(
-        SplitsReceiver[] calldata currReceivers,
-        SplitsReceiver[] calldata newReceivers
-    ) public override returns (uint128 collected, uint128 split) {
-        return dripsHub.setSplits(currReceivers, newReceivers);
+    function setSplits(SplitsReceiver[] calldata receivers) public override {
+        dripsHub.setSplits(receivers);
     }
 }

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -160,7 +160,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testSetSplitsCanBePaused() public {
         admin.pause();
-        try admin.setSplits(new SplitsReceiver[](0), new SplitsReceiver[](0)) {
+        try admin.setSplits(new SplitsReceiver[](0)) {
             assertTrue(false, "SetSplits hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid setSplits revert reason");


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/96, blocked by https://github.com/radicle-dev/radicle-drips-hub/pull/105.

Stops `setSplits` from collecting. Adds asset ID to events, as of now it's just `DUMMY_ASSET` and it's unindexed until we remove support for raw address user identity and free up indexed event slots.

The next step is to add the actual asset ID to the DripsHub API.