### PR TITLE
Prepare for splitting without collecting API

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -239,7 +239,7 @@ abstract contract DripsHub {
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collected The collected amount
     /// @return split The amount split to the user's splits receivers
-    function collectable(
+    function collectableAll(
         address user,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -283,12 +283,12 @@ abstract contract DripsHub {
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collected The collected amount
     /// @return split The amount split to the user's splits receivers
-    function collect(
+    function collectAll(
         address user,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers
     ) public virtual returns (uint128 collected, uint128 split) {
-        (collected, split) = _collectInternal(user, assetId, currReceivers);
+        (collected, split) = _collectAllInternal(user, assetId, currReceivers);
         _transfer(user, assetId, int128(collected));
     }
 
@@ -343,7 +343,7 @@ abstract contract DripsHub {
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collected The collected amount
     /// @return split The amount split to the user's splits receivers
-    function _collectInternal(
+    function _collectAllInternal(
         address user,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -292,13 +292,17 @@ abstract contract DripsHub {
         _transfer(user, assetId, int128(collected));
     }
 
-    /// @notice Counts cycles which will need to be analyzed when collecting or flushing.
-    /// This function can be used to detect that there are too many cycles
-    /// to analyze in a single transaction and flushing is needed.
+    /// @notice Counts cycles which will need to be analyzed when collecting drips.
+    /// This function can be used to detect that there are
+    /// too many cycles to analyze in a single transaction.
     /// @param user The user
     /// @param assetId The used asset ID
-    /// @return flushable The number of cycles which can be flushed
-    function flushableCycles(address user, uint256 assetId) public view returns (uint64 flushable) {
+    /// @return cycles The number of cycles which can be flushed
+    function receivableDripsCycles(address user, uint256 assetId)
+        public
+        view
+        returns (uint64 cycles)
+    {
         uint64 nextCollectedCycle = _dripsHubStorage()
         .dripsStates[calcUserId(user)][assetId].nextCollectedCycle;
         if (nextCollectedCycle == 0) return 0;
@@ -325,7 +329,7 @@ abstract contract DripsHub {
         uint256 assetId,
         uint64 maxCycles
     ) public virtual returns (uint64 flushable) {
-        flushable = flushableCycles(user, assetId);
+        flushable = receivableDripsCycles(user, assetId);
         uint64 cycles = maxCycles < flushable ? maxCycles : flushable;
         flushable -= cycles;
         uint128 collected = _flushCyclesInternal(user, assetId, cycles);
@@ -358,7 +362,7 @@ abstract contract DripsHub {
         if (collected > 0) splitsState.balances[assetId].unsplit = 0;
 
         // Collectable from cycles
-        uint64 cycles = flushableCycles(user, assetId);
+        uint64 cycles = receivableDripsCycles(user, assetId);
         collected += _flushCyclesInternal(user, assetId, cycles);
 
         // split when collected

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -60,26 +60,22 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
         return super.collectAll(user, assetId, currReceivers);
     }
 
-    /// @notice Flushes uncollected cycles of the user.
-    /// Flushed cycles won't need to be analyzed when the user collects from them.
-    /// Calling this function does not collect and does not affect the collectable amount.
-    ///
-    /// This function is needed when collecting funds received over a period so long, that the gas
-    /// needed for analyzing all the uncollected cycles can't fit in a single transaction.
-    /// Calling this function allows spreading the analysis cost over multiple transactions.
-    /// A cycle is never flushed more than once, even if this function is called many times.
+    /// @notice Receive drips from uncollected cycles of the user.
+    /// Received drips cycles won't need to be analyzed ever again.
+    /// Calling this function does not collect but makes the funds ready to be split and collected.
     /// @param user The user
     /// @param assetId The used asset ID
-    /// @param maxCycles The maximum number of flushed cycles.
-    /// If too low, flushing will be cheap, but will cut little gas from the next collection.
-    /// If too high, flushing may become too expensive to fit in a single transaction.
-    /// @return flushable The number of cycles which can be flushed
-    function flushCycles(
+    /// @param maxCycles The maximum number of received drips cycles.
+    /// If too low, receiving will be cheap, but may not cover many cycles.
+    /// If too high, receiving may become too expensive to fit in a single transaction.
+    /// @return receivedAmt The received amount
+    /// @return receivableCycles The number of cycles which still can be received
+    function receiveDrips(
         address user,
         uint256 assetId,
         uint64 maxCycles
-    ) public override whenNotPaused returns (uint64 flushable) {
-        return super.flushCycles(user, assetId, maxCycles);
+    ) public override whenNotPaused returns (uint128 receivedAmt, uint64 receivableCycles) {
+        return super.receiveDrips(user, assetId, maxCycles);
     }
 
     /// @notice Authorizes the contract upgrade. See `UUPSUpgradable` docs for more details.

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -52,12 +52,12 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collected The collected amount
     /// @return split The amount split to the user's splits receivers
-    function collect(
+    function collectAll(
         address user,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers
     ) public override whenNotPaused returns (uint128 collected, uint128 split) {
-        return super.collect(user, assetId, currReceivers);
+        return super.collectAll(user, assetId, currReceivers);
     }
 
     /// @notice Flushes uncollected cycles of the user.

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -145,9 +145,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collect(receiver, 99);
     }
 
-    function testCollectableRevertsIfInvalidCurrSplitsReceivers() public {
+    function testCollectableAllRevertsIfInvalidCurrSplitsReceivers() public {
         setSplits(user, splitsReceivers(receiver, 1));
-        try user.collectable(defaultAsset, splitsReceivers(receiver, 2)) {
+        try user.collectableAll(defaultAsset, splitsReceivers(receiver, 2)) {
             assertTrue(false, "Collectable hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(
@@ -178,7 +178,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertDripsBalance(user, 0);
         warpToCycleEnd();
         // Receiver had 10 seconds paying 10 per second
-        assertCollectable(receiver, 100);
+        assertCollectableAll(receiver, 100);
         changeBalance(user, 0, 60);
         warpBy(5);
         // User had 5 seconds paying 10 per second
@@ -470,7 +470,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
         warpToCycleEnd();
-        assertCollectable(receiver2, 0);
+        assertCollectableAll(receiver2, 0);
         // Receiver1 had 1 second paying 10 per second of which 10 is split
         collect(receiver1, 0, 10);
         // Receiver2 got 10 split from receiver1
@@ -487,7 +487,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         // Receiver1 had 1 second paying 5 per second and was given 5 of which 10 is split
         collect(user1, 0, 10);
         // Receiver1 wasn't a splits receiver when user1 was collecting
-        assertCollectable(receiver1, 0);
+        assertCollectableAll(receiver1, 0);
         // Receiver2 was a splits receiver when user1 was collecting
         collect(receiver2, 10);
     }
@@ -498,8 +498,8 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
         setSplits(receiver2, splitsReceivers(receiver3, totalWeight));
         warpToCycleEnd();
-        assertCollectable(receiver2, 0);
-        assertCollectable(receiver3, 0);
+        assertCollectableAll(receiver2, 0);
+        assertCollectableAll(receiver3, 0);
         // Receiver1 had 1 second paying 10 per second of which 10 is split
         collect(receiver1, 0, 10);
         // Receiver2 got 10 split from receiver1 of which 10 is split
@@ -514,7 +514,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
         warpToCycleEnd();
         // Receiver2 had 1 second paying 5 per second
-        assertCollectable(receiver2, 5);
+        assertCollectableAll(receiver2, 5);
         // Receiver1 had 1 second paying 5 per second
         collect(receiver1, 0, 5);
         // Receiver2 had 1 second paying 5 per second and got 5 split from receiver1
@@ -529,8 +529,8 @@ abstract contract DripsHubTest is DripsHubUserUtils {
             splitsReceivers(receiver2, totalWeight / 4, receiver3, totalWeight / 2)
         );
         warpToCycleEnd();
-        assertCollectable(receiver2, 0);
-        assertCollectable(receiver3, 0);
+        assertCollectableAll(receiver2, 0);
+        assertCollectableAll(receiver3, 0);
         // Receiver1 had 1 second paying 10 per second, of which 3/4 is split, which is 7
         collect(receiver1, 3, 7);
         // Receiver2 got 1/3 of 7 split from receiver1, which is 2

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -555,7 +555,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collectAll(receiver3, 2);
     }
 
-    function testFlushSomeCycles() public {
+    function testReceiveSomeDripsCycles() public {
         // Enough for 3 cycles
         uint128 amt = dripsHub.cycleSecs() * 3;
         warpToCycleEnd();
@@ -563,11 +563,11 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();
-        flushCycles(receiver, 3, 2, 1);
+        receiveDrips(receiver, 3, 2, 1);
         collectAll(receiver, amt);
     }
 
-    function testFlushAllCycles() public {
+    function testReceiveAllDripsCycles() public {
         // Enough for 3 cycles
         uint128 amt = dripsHub.cycleSecs() * 3;
         warpToCycleEnd();
@@ -575,7 +575,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();
-        flushCycles(receiver, 3, type(uint64).max, 0);
+        receiveDrips(receiver, 3, type(uint64).max, 0);
         collectAll(receiver, amt);
     }
 

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -53,7 +53,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 85, 0);
         warpToCycleEnd();
         // Receiver 1 had 15 seconds paying 1 per second
-        collect(receiver, 15);
+        collectAll(receiver, 15);
     }
 
     function testAllowsDrippingToASingleReceiverForFuzzyTime(uint8 cycles, uint8 timeInCycle)
@@ -67,16 +67,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, balance - time, 0);
         warpToCycleEnd();
         // User had `time` seconds paying 1 per second
-        collect(receiver, time);
+        collectAll(receiver, time);
     }
 
     function testAllowsDrippingToMultipleReceivers() public {
         setDrips(user, 0, 6, dripsReceivers(receiver1, 1, receiver2, 2));
         warpToCycleEnd();
         // User had 2 seconds paying 1 per second
-        collect(receiver1, 2);
+        collectAll(receiver1, 2);
         // User had 2 seconds paying 2 per second
-        collect(receiver2, 4);
+        collectAll(receiver2, 4);
     }
 
     function testDripsSomeFundsToTwoReceivers() public {
@@ -86,9 +86,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 72, 0);
         warpToCycleEnd();
         // Receiver 1 had 14 seconds paying 1 per second
-        collect(receiver1, 14);
+        collectAll(receiver1, 14);
         // Receiver 2 had 14 seconds paying 1 per second
-        collect(receiver2, 14);
+        collectAll(receiver2, 14);
     }
 
     function testDripsSomeFundsFromTwoUsersToASingleReceiver() public {
@@ -102,29 +102,29 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user2, 70, 0);
         warpToCycleEnd();
         // Receiver had 2 seconds paying 1 per second and 15 seconds paying 3 per second
-        collect(receiver, 47);
+        collectAll(receiver, 47);
     }
 
     function testDoesNotRequireReceiverToBeInitialized() public {
-        collect(receiver, 0);
+        collectAll(receiver, 0);
     }
 
     function testAllowsCollectingFundsWhileTheyAreBeingDripped() public {
         setDrips(user, 0, dripsHub.cycleSecs() + 10, dripsReceivers(receiver, 1));
         warpToCycleEnd();
         // Receiver had cycleSecs seconds paying 1 per second
-        collect(receiver, dripsHub.cycleSecs());
+        collectAll(receiver, dripsHub.cycleSecs());
         warpBy(7);
         // User had cycleSecs + 7 seconds paying 1 per second
         changeBalance(user, 3, 0);
         warpToCycleEnd();
         // Receiver had 7 seconds paying 1 per second
-        collect(receiver, 7);
+        collectAll(receiver, 7);
     }
 
-    function testCollectRevertsIfInvalidCurrSplitsReceivers() public {
+    function testCollectAllRevertsIfInvalidCurrSplitsReceivers() public {
         setSplits(user, splitsReceivers(receiver, 1));
-        try user.collect(address(user), defaultAsset, splitsReceivers(receiver, 2)) {
+        try user.collectAll(address(user), defaultAsset, splitsReceivers(receiver, 2)) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Invalid current splits receivers", "Invalid collect revert reason");
@@ -142,7 +142,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         // Nothing more will be dripped
         warpToCycleEnd();
         changeBalance(user, 1, 0);
-        collect(receiver, 99);
+        collectAll(receiver, 99);
     }
 
     function testCollectableAllRevertsIfInvalidCurrSplitsReceivers() public {
@@ -168,7 +168,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 10, 0);
         warpToCycleEnd();
         // Receiver had 11 seconds paying 10 per second
-        collect(receiver, 110);
+        collectAll(receiver, 110);
     }
 
     function testAllowsToppingUpAfterFundsRunOut() public {
@@ -185,7 +185,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 10, 0);
         warpToCycleEnd();
         // Receiver had 15 seconds paying 10 per second
-        collect(receiver, 150);
+        collectAll(receiver, 150);
     }
 
     function testAllowsDrippingWhichShouldEndAfterMaxTimestamp() public {
@@ -196,7 +196,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, balance - 10, 0);
         warpToCycleEnd();
         // Receiver had 10 seconds paying 1 per second
-        collect(receiver, 10);
+        collectAll(receiver, 10);
     }
 
     function testAllowsNoDripsReceiversUpdate() public {
@@ -205,7 +205,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         // User had 1 second paying 3 per second
         setDrips(user, 3, 3, dripsReceivers(receiver, 3));
         warpToCycleEnd();
-        collect(receiver, 6);
+        collectAll(receiver, 6);
     }
 
     function testAllowsChangingReceiversWhileDripping() public {
@@ -217,9 +217,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 16, 0);
         warpToCycleEnd();
         // Receiver1 had 3 seconds paying 6 per second and 4 seconds paying 4 per second
-        collect(receiver1, 34);
+        collectAll(receiver1, 34);
         // Receiver2 had 3 seconds paying 6 per second and 4 seconds paying 8 per second
-        collect(receiver2, 50);
+        collectAll(receiver2, 50);
     }
 
     function testAllowsRemovingReceiversWhileDripping() public {
@@ -233,9 +233,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, 30, 0);
         warpToCycleEnd();
         // Receiver1 had 3 seconds paying 5 per second
-        collect(receiver1, 15);
+        collectAll(receiver1, 15);
         // Receiver2 had 3 seconds paying 5 per second and 4 seconds paying 10 per second
-        collect(receiver2, 55);
+        collectAll(receiver2, 55);
     }
 
     function testLimitsTheTotalReceiversCount() public {
@@ -331,7 +331,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertDripsBalance(user, 0);
         warpToCycleEnd();
         // User had 1 second paying 10 per second
-        collect(user, 10);
+        collectAll(user, 10);
     }
 
     function testAllowsWithdrawalOfMoreThanDripsBalance() public {
@@ -356,14 +356,14 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertBalance(user, expectedBalance);
         warpToCycleEnd();
         // Receiver had 4 seconds paying 1 per second
-        collect(receiver, 4);
+        collectAll(receiver, 4);
     }
 
-    function testAnybodyCanCallCollect() public {
+    function testAnybodyCanCallCollectAll() public {
         setDrips(user1, 0, 10, dripsReceivers(receiver, 10));
         warpToCycleEnd();
         // Receiver had 1 second paying 10 per second
-        collect(user2, receiver, 10);
+        collectAll(user2, receiver, 10);
     }
 
     function testUserAndTheirAccountAreIndependent() public {
@@ -378,9 +378,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, ACCOUNT_1, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
-        collect(receiver1, 8);
+        collectAll(receiver1, 8);
         // Receiver2 had 2 second paying 1 per second
-        collect(receiver2, 2);
+        collectAll(receiver2, 2);
     }
 
     function testUserAccountsAreIndependent() public {
@@ -395,9 +395,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user, ACCOUNT_2, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
-        collect(receiver1, 8);
+        collectAll(receiver1, 8);
         // Receiver2 had 2 second paying 1 per second
-        collect(receiver2, 2);
+        collectAll(receiver2, 2);
     }
 
     function testAccountsOfDifferentUsersAreIndependent() public {
@@ -412,9 +412,9 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         changeBalance(user2, ACCOUNT_1, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
-        collect(receiver1, 8);
+        collectAll(receiver1, 8);
         // Receiver2 had 2 second paying 1 per second
-        collect(receiver2, 2);
+        collectAll(receiver2, 2);
     }
 
     function testLimitsTheTotalSplitsReceiversCount() public {
@@ -465,16 +465,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         );
     }
 
-    function testCollectSplits() public {
+    function testCollectAllSplits() public {
         uint32 totalWeight = dripsHub.TOTAL_SPLITS_WEIGHT();
         setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
         warpToCycleEnd();
         assertCollectableAll(receiver2, 0);
         // Receiver1 had 1 second paying 10 per second of which 10 is split
-        collect(receiver1, 0, 10);
+        collectAll(receiver1, 0, 10);
         // Receiver2 got 10 split from receiver1
-        collect(receiver2, 10);
+        collectAll(receiver2, 10);
     }
 
     function testUncollectedFundsAreSplitUsingCurrentConfig() public {
@@ -485,14 +485,14 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         give(user2, user1, 5);
         setSplits(user1, splitsReceivers(receiver2, totalWeight));
         // Receiver1 had 1 second paying 5 per second and was given 5 of which 10 is split
-        collect(user1, 0, 10);
+        collectAll(user1, 0, 10);
         // Receiver1 wasn't a splits receiver when user1 was collecting
         assertCollectableAll(receiver1, 0);
         // Receiver2 was a splits receiver when user1 was collecting
-        collect(receiver2, 10);
+        collectAll(receiver2, 10);
     }
 
-    function testCollectSplitsFundsFromSplits() public {
+    function testCollectAllSplitsFundsFromSplits() public {
         uint32 totalWeight = dripsHub.TOTAL_SPLITS_WEIGHT();
         setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
@@ -501,14 +501,14 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertCollectableAll(receiver2, 0);
         assertCollectableAll(receiver3, 0);
         // Receiver1 had 1 second paying 10 per second of which 10 is split
-        collect(receiver1, 0, 10);
+        collectAll(receiver1, 0, 10);
         // Receiver2 got 10 split from receiver1 of which 10 is split
-        collect(receiver2, 0, 10);
+        collectAll(receiver2, 0, 10);
         // Receiver3 got 10 split from receiver2
-        collect(receiver3, 10);
+        collectAll(receiver3, 10);
     }
 
-    function testCollectMixesDripsAndSplits() public {
+    function testCollectAllMixesDripsAndSplits() public {
         uint32 totalWeight = dripsHub.TOTAL_SPLITS_WEIGHT();
         setDrips(user, 0, 10, dripsReceivers(receiver1, 5, receiver2, 5));
         setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
@@ -516,12 +516,12 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         // Receiver2 had 1 second paying 5 per second
         assertCollectableAll(receiver2, 5);
         // Receiver1 had 1 second paying 5 per second
-        collect(receiver1, 0, 5);
+        collectAll(receiver1, 0, 5);
         // Receiver2 had 1 second paying 5 per second and got 5 split from receiver1
-        collect(receiver2, 10);
+        collectAll(receiver2, 10);
     }
 
-    function testCollectSplitsFundsBetweenReceiverAndSplits() public {
+    function testCollectAllSplitsFundsBetweenReceiverAndSplits() public {
         uint32 totalWeight = dripsHub.TOTAL_SPLITS_WEIGHT();
         setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
         setSplits(
@@ -532,11 +532,11 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertCollectableAll(receiver2, 0);
         assertCollectableAll(receiver3, 0);
         // Receiver1 had 1 second paying 10 per second, of which 3/4 is split, which is 7
-        collect(receiver1, 3, 7);
+        collectAll(receiver1, 3, 7);
         // Receiver2 got 1/3 of 7 split from receiver1, which is 2
-        collect(receiver2, 2);
+        collectAll(receiver2, 2);
         // Receiver3 got 2/3 of 7 split from receiver1, which is 5
-        collect(receiver3, 5);
+        collectAll(receiver3, 5);
     }
 
     function testCanSplitAllWhenCollectedDoesntSplitEvenly() public {
@@ -548,11 +548,11 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         );
         warpToCycleEnd();
         // Receiver1 had 1 second paying 3 per second of which 3 is split
-        collect(receiver1, 0, 3);
+        collectAll(receiver1, 0, 3);
         // Receiver2 got 1 split from receiver
-        collect(receiver2, 1);
+        collectAll(receiver2, 1);
         // Receiver3 got 2 split from receiver
-        collect(receiver3, 2);
+        collectAll(receiver3, 2);
     }
 
     function testFlushSomeCycles() public {
@@ -564,7 +564,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         warpToCycleEnd();
         warpToCycleEnd();
         flushCycles(receiver, 3, 2, 1);
-        collect(receiver, amt);
+        collectAll(receiver, amt);
     }
 
     function testFlushAllCycles() public {
@@ -576,16 +576,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         warpToCycleEnd();
         warpToCycleEnd();
         flushCycles(receiver, 3, type(uint64).max, 0);
-        collect(receiver, amt);
+        collectAll(receiver, amt);
     }
 
     function testFundsGivenFromUserCanBeCollected() public {
         give(user, receiver, 10);
-        collect(receiver, 10);
+        collectAll(receiver, 10);
     }
 
     function testFundsGivenFromAccountCanBeCollected() public {
         give(user, ACCOUNT_1, receiver, 10);
-        collect(receiver, 10);
+        collectAll(receiver, 10);
     }
 }

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -50,12 +50,12 @@ abstract contract DripsHubUser {
 
     function setSplits(SplitsReceiver[] calldata receivers) public virtual;
 
-    function collect(
+    function collectAll(
         address receiver,
         uint256 assetId,
         SplitsReceiver[] calldata currReceivers
     ) public returns (uint128 collected, uint128 split) {
-        return dripsHub.collect(receiver, assetId, currReceivers);
+        return dripsHub.collectAll(receiver, assetId, currReceivers);
     }
 
     function collectableAll(uint256 assetId, SplitsReceiver[] calldata currReceivers)

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -70,8 +70,11 @@ abstract contract DripsHubUser {
         return dripsHub.receivableDripsCycles(address(this), assetId);
     }
 
-    function flushCycles(uint256 assetId, uint64 maxCycles) public returns (uint64 flushable) {
-        return dripsHub.flushCycles(address(this), assetId, maxCycles);
+    function receiveDrips(uint256 assetId, uint64 maxCycles)
+        public
+        returns (uint128 receivedAmt, uint64 receivableCycles)
+    {
+        return dripsHub.receiveDrips(address(this), assetId, maxCycles);
     }
 
     function hashDrips(

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -66,8 +66,8 @@ abstract contract DripsHubUser {
         return dripsHub.collectableAll(address(this), assetId, currReceivers);
     }
 
-    function flushableCycles(uint256 assetId) public view returns (uint64 flushable) {
-        return dripsHub.flushableCycles(address(this), assetId);
+    function receivableDripsCycles(uint256 assetId) public view returns (uint64 cycles) {
+        return dripsHub.receivableDripsCycles(address(this), assetId);
     }
 
     function flushCycles(uint256 assetId, uint64 maxCycles) public returns (uint64 flushable) {

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -58,12 +58,12 @@ abstract contract DripsHubUser {
         return dripsHub.collect(receiver, assetId, currReceivers);
     }
 
-    function collectable(uint256 assetId, SplitsReceiver[] calldata currReceivers)
+    function collectableAll(uint256 assetId, SplitsReceiver[] calldata currReceivers)
         public
         view
         returns (uint128 collected, uint128 split)
     {
-        return dripsHub.collectable(address(this), assetId, currReceivers);
+        return dripsHub.collectableAll(address(this), assetId, currReceivers);
     }
 
     function flushableCycles(uint256 assetId) public view returns (uint64 flushable) {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -529,15 +529,15 @@ abstract contract DripsHubUserUtils is DSTest {
         uint64 maxCycles,
         uint64 expectedFlushableAfter
     ) internal {
-        assertFlushableCycles(user, expectedFlushableBefore);
+        assertReceivableDripsCycles(user, expectedFlushableBefore);
         uint64 flushableLeft = user.flushCycles(defaultAsset, maxCycles);
         assertEq(flushableLeft, expectedFlushableAfter, "Invalid flushable cycles left");
-        assertFlushableCycles(user, expectedFlushableAfter);
+        assertReceivableDripsCycles(user, expectedFlushableAfter);
     }
 
-    function assertFlushableCycles(DripsHubUser user, uint64 expectedFlushable) internal {
-        uint64 actualFlushable = user.flushableCycles(defaultAsset);
-        assertEq(actualFlushable, expectedFlushable, "Invalid flushable cycles");
+    function assertReceivableDripsCycles(DripsHubUser user, uint64 expectedCycles) internal {
+        uint64 actualCycles = user.receivableDripsCycles(defaultAsset);
+        assertEq(actualCycles, expectedCycles, "Invalid receivable drips cycles");
     }
 
     function assertBalance(DripsHubUser user, uint256 expected) internal {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -338,12 +338,12 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 amt
     ) internal {
         uint256 expectedBalance = uint256(user.balance(asset) - amt);
-        uint128 expectedCollectable = totalCollectable(asset, receiver) + amt;
+        uint128 expectedCollectable = totalCollectableAll(asset, receiver) + amt;
 
         user.give(address(receiver), asset, amt);
 
         assertBalance(asset, user, expectedBalance);
-        assertTotalCollectable(asset, receiver, expectedCollectable);
+        assertTotalCollectableAll(asset, receiver, expectedCollectable);
     }
 
     function give(
@@ -353,12 +353,12 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 amt
     ) internal {
         uint256 expectedBalance = uint256(user.balance(defaultAsset) - amt);
-        uint128 expectedCollectable = totalCollectable(defaultAsset, receiver) + amt;
+        uint128 expectedCollectable = totalCollectableAll(defaultAsset, receiver) + amt;
 
         user.give(account, address(receiver), defaultAsset, amt);
 
         assertBalance(defaultAsset, user, expectedBalance);
-        assertTotalCollectable(defaultAsset, receiver, expectedCollectable);
+        assertTotalCollectableAll(defaultAsset, receiver, expectedCollectable);
     }
 
     function splitsReceivers() internal pure returns (SplitsReceiver[] memory list) {
@@ -459,7 +459,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 expectedCollected,
         uint128 expectedSplit
     ) internal {
-        assertCollectable(asset, collected, expectedCollected, expectedSplit);
+        assertCollectableAll(asset, collected, expectedCollected, expectedSplit);
         uint256 expectedBalance = collected.balance(asset) + expectedCollected;
 
         (uint128 collectedAmt, uint128 splitAmt) = user.collect(
@@ -470,37 +470,37 @@ abstract contract DripsHubUserUtils is DSTest {
 
         assertEq(collectedAmt, expectedCollected, "Invalid collected amount");
         assertEq(splitAmt, expectedSplit, "Invalid split amount");
-        assertCollectable(asset, collected, 0);
+        assertCollectableAll(asset, collected, 0);
         assertBalance(asset, collected, expectedBalance);
     }
 
-    function assertCollectable(DripsHubUser user, uint128 expected) internal {
-        assertCollectable(defaultAsset, user, expected, 0);
+    function assertCollectableAll(DripsHubUser user, uint128 expected) internal {
+        assertCollectableAll(defaultAsset, user, expected, 0);
     }
 
-    function assertCollectable(
+    function assertCollectableAll(
         uint256 asset,
         DripsHubUser user,
         uint128 expected
     ) internal {
-        assertCollectable(asset, user, expected, 0);
+        assertCollectableAll(asset, user, expected, 0);
     }
 
-    function assertCollectable(
+    function assertCollectableAll(
         DripsHubUser user,
         uint128 expectedCollected,
         uint128 expectedSplit
     ) internal {
-        assertCollectable(defaultAsset, user, expectedCollected, expectedSplit);
+        assertCollectableAll(defaultAsset, user, expectedCollected, expectedSplit);
     }
 
-    function assertCollectable(
+    function assertCollectableAll(
         uint256 asset,
         DripsHubUser user,
         uint128 expectedCollected,
         uint128 expectedSplit
     ) internal {
-        (uint128 actualCollected, uint128 actualSplit) = user.collectable(
+        (uint128 actualCollected, uint128 actualSplit) = user.collectableAll(
             asset,
             getCurrSplitsReceivers(user)
         );
@@ -508,18 +508,18 @@ abstract contract DripsHubUserUtils is DSTest {
         assertEq(actualSplit, expectedSplit, "Invalid split");
     }
 
-    function totalCollectable(uint256 asset, DripsHubUser user) internal view returns (uint128) {
+    function totalCollectableAll(uint256 asset, DripsHubUser user) internal view returns (uint128) {
         SplitsReceiver[] memory splits = getCurrSplitsReceivers(user);
-        (uint128 collectable, uint128 splittable) = user.collectable(asset, splits);
+        (uint128 collectable, uint128 splittable) = user.collectableAll(asset, splits);
         return collectable + splittable;
     }
 
-    function assertTotalCollectable(
+    function assertTotalCollectableAll(
         uint256 asset,
         DripsHubUser user,
         uint128 expectedCollectable
     ) internal {
-        uint128 actualCollectable = totalCollectable(asset, user);
+        uint128 actualCollectable = totalCollectableAll(asset, user);
         assertEq(actualCollectable, expectedCollectable, "Invalid total collectable");
     }
 

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -523,16 +523,16 @@ abstract contract DripsHubUserUtils is DSTest {
         assertEq(actualCollectable, expectedCollectable, "Invalid total collectable");
     }
 
-    function flushCycles(
+    function receiveDrips(
         DripsHubUser user,
-        uint64 expectedFlushableBefore,
+        uint64 expectedReceivableBefore,
         uint64 maxCycles,
-        uint64 expectedFlushableAfter
+        uint64 expectedReceivableAfter
     ) internal {
-        assertReceivableDripsCycles(user, expectedFlushableBefore);
-        uint64 flushableLeft = user.flushCycles(defaultAsset, maxCycles);
-        assertEq(flushableLeft, expectedFlushableAfter, "Invalid flushable cycles left");
-        assertReceivableDripsCycles(user, expectedFlushableAfter);
+        assertReceivableDripsCycles(user, expectedReceivableBefore);
+        (, uint64 receivableLeft) = user.receiveDrips(defaultAsset, maxCycles);
+        assertEq(receivableLeft, expectedReceivableAfter, "Invalid receivable drips cycles left");
+        assertReceivableDripsCycles(user, expectedReceivableAfter);
     }
 
     function assertReceivableDripsCycles(DripsHubUser user, uint64 expectedCycles) internal {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -415,44 +415,44 @@ abstract contract DripsHubUserUtils is DSTest {
         assertEq(actual, expected, "Invalid splits hash");
     }
 
-    function collect(DripsHubUser user, uint128 expectedAmt) internal {
-        collect(defaultAsset, user, user, expectedAmt, 0);
+    function collectAll(DripsHubUser user, uint128 expectedAmt) internal {
+        collectAll(defaultAsset, user, user, expectedAmt, 0);
     }
 
-    function collect(
+    function collectAll(
         uint256 asset,
         DripsHubUser user,
         uint128 expectedAmt
     ) internal {
-        collect(asset, user, user, expectedAmt, 0);
+        collectAll(asset, user, user, expectedAmt, 0);
     }
 
-    function collect(
+    function collectAll(
         DripsHubUser user,
         uint128 expectedCollected,
         uint128 expectedSplit
     ) internal {
-        collect(defaultAsset, user, user, expectedCollected, expectedSplit);
+        collectAll(defaultAsset, user, user, expectedCollected, expectedSplit);
     }
 
-    function collect(
+    function collectAll(
         uint256 asset,
         DripsHubUser user,
         uint128 expectedCollected,
         uint128 expectedSplit
     ) internal {
-        collect(asset, user, user, expectedCollected, expectedSplit);
+        collectAll(asset, user, user, expectedCollected, expectedSplit);
     }
 
-    function collect(
+    function collectAll(
         DripsHubUser user,
         DripsHubUser collected,
         uint128 expectedAmt
     ) internal {
-        collect(defaultAsset, user, collected, expectedAmt, 0);
+        collectAll(defaultAsset, user, collected, expectedAmt, 0);
     }
 
-    function collect(
+    function collectAll(
         uint256 asset,
         DripsHubUser user,
         DripsHubUser collected,
@@ -462,7 +462,7 @@ abstract contract DripsHubUserUtils is DSTest {
         assertCollectableAll(asset, collected, expectedCollected, expectedSplit);
         uint256 expectedBalance = collected.balance(asset) + expectedCollected;
 
-        (uint128 collectedAmt, uint128 splitAmt) = user.collect(
+        (uint128 collectedAmt, uint128 splitAmt) = user.collectAll(
             address(collected),
             asset,
             getCurrSplitsReceivers(user)

--- a/src/test/ERC20DripsHub.t.sol
+++ b/src/test/ERC20DripsHub.t.sol
@@ -62,23 +62,23 @@ contract ERC20DripsHubTest is ManagedDripsHubTest {
 
         warpToCycleEnd();
         // receiver1 had 1.5 cycles of 4 per second
-        collect(defaultAsset, receiver1, 6 * cycleLength);
+        collectAll(defaultAsset, receiver1, 6 * cycleLength);
         // receiver1 had 1.5 cycles of 2 per second
-        collect(defaultAsset, receiver2, 3 * cycleLength);
+        collectAll(defaultAsset, receiver2, 3 * cycleLength);
         // receiver1 had 1 cycle of 3 per second
-        collect(otherAsset, receiver1, 3 * cycleLength);
+        collectAll(otherAsset, receiver1, 3 * cycleLength);
         // receiver2 received nothing
-        collect(otherAsset, receiver2, 0);
+        collectAll(otherAsset, receiver2, 0);
 
         warpToCycleEnd();
         // receiver1 received nothing
-        collect(defaultAsset, receiver1, 0);
+        collectAll(defaultAsset, receiver1, 0);
         // receiver2 received nothing
-        collect(defaultAsset, receiver2, 0);
+        collectAll(defaultAsset, receiver2, 0);
         // receiver1 had 1 cycle of 3 per second
-        collect(otherAsset, receiver1, 3 * cycleLength);
+        collectAll(otherAsset, receiver1, 3 * cycleLength);
         // receiver2 received nothing
-        collect(otherAsset, receiver2, 0);
+        collectAll(otherAsset, receiver2, 0);
     }
 
     function testSplitsConfigurationIsCommonBetweenTokens() public {
@@ -86,9 +86,9 @@ contract ERC20DripsHubTest is ManagedDripsHubTest {
         setSplits(user, splitsReceivers(receiver1, totalWeight / 10));
         give(defaultAsset, receiver2, user, 30);
         give(otherAsset, receiver2, user, 100);
-        collect(defaultAsset, user, 27, 3);
-        collect(otherAsset, user, 90, 10);
-        collect(defaultAsset, receiver1, 3);
-        collect(otherAsset, receiver1, 10);
+        collectAll(defaultAsset, user, 27, 3);
+        collectAll(otherAsset, user, 90, 10);
+        collectAll(defaultAsset, receiver1, 3);
+        collectAll(otherAsset, receiver1, 10);
     }
 }

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -104,9 +104,9 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
         }
     }
 
-    function testCollectCanBePaused() public {
+    function testCollectAllCanBePaused() public {
         admin.pause();
-        try admin.collect(address(admin), defaultAsset, new SplitsReceiver[](0)) {
+        try admin.collectAll(address(admin), defaultAsset, new SplitsReceiver[](0)) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid collect revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -113,12 +113,12 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
         }
     }
 
-    function testFlushCyclesCanBePaused() public {
+    function testReceiveDripsCanBePaused() public {
         admin.pause();
-        try admin.flushCycles(defaultAsset, 1) {
-            assertTrue(false, "FlushCycles hasn't reverted");
+        try admin.receiveDrips(defaultAsset, 1) {
+            assertTrue(false, "ReceiveDrips hasn't reverted");
         } catch Error(string memory reason) {
-            assertEq(reason, ERROR_PAUSED, "Invalid flushCycles revert reason");
+            assertEq(reason, ERROR_PAUSED, "Invalid receiveDrips revert reason");
         }
     }
 


### PR DESCRIPTION
First part of https://github.com/radicle-dev/radicle-drips-hub/issues/97. Adjusts the existing API for splitting without collecting but doesn't add any new functions yet.