### PR TITLE
Replace user accounts with user IDs

### DIFF
--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -50,7 +50,7 @@ contract ERC20DripsHub is ManagedDripsHub {
     ) public whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _setDrips(
-                _userOrAccount(msg.sender),
+                calcUserId(msg.sender),
                 assetId,
                 lastUpdate,
                 lastBalance,
@@ -60,11 +60,10 @@ contract ERC20DripsHub is ManagedDripsHub {
             );
     }
 
-    /// @notice Sets the drips configuration of an account of the `msg.sender`.
-    /// See `setDrips` for more details
-    /// @param account The account
+    /// @notice Sets the drips configuration of the user. See `setDrips` for more details.
+    /// @param userId The user ID
     function setDrips(
-        uint256 account,
+        uint256 userId,
         uint256 assetId,
         uint64 lastUpdate,
         uint128 lastBalance,
@@ -74,7 +73,7 @@ contract ERC20DripsHub is ManagedDripsHub {
     ) public whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _setDrips(
-                _userOrAccount(msg.sender, account),
+                userId,
                 assetId,
                 lastUpdate,
                 lastBalance,
@@ -95,23 +94,23 @@ contract ERC20DripsHub is ManagedDripsHub {
         uint256 assetId,
         uint128 amt
     ) public whenNotPaused {
-        _give(_userOrAccount(msg.sender), receiver, assetId, amt);
+        _give(calcUserId(msg.sender), receiver, assetId, amt);
     }
 
-    /// @notice Gives funds from the account of the `msg.sender` to the receiver.
+    /// @notice Gives funds from the user to the receiver.
     /// The receiver can collect them immediately.
     /// Transfers the funds to be given from the sender's wallet to the drips hub contract.
-    /// @param account The account
+    /// @param userId The user ID
     /// @param receiver The receiver
     /// @param assetId The used asset ID
     /// @param amt The given amount
     function give(
-        uint256 account,
+        uint256 userId,
         address receiver,
         uint256 assetId,
         uint128 amt
     ) public whenNotPaused {
-        _give(_userOrAccount(msg.sender, account), receiver, assetId, amt);
+        _give(userId, receiver, assetId, amt);
     }
 
     /// @notice Sets user splits configuration.

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -44,7 +44,7 @@ contract EthDripsHub is ManagedDripsHub {
     ) public payable whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _setDrips(
-                _userOrAccount(msg.sender),
+                calcUserId(msg.sender),
                 ASSET_ID,
                 lastUpdate,
                 lastBalance,
@@ -54,11 +54,10 @@ contract EthDripsHub is ManagedDripsHub {
             );
     }
 
-    /// @notice Sets the drips configuration of an account of the `msg.sender`.
-    /// See `setDrips` for more details
-    /// @param account The account
+    /// @notice Sets the drips configuration of the user. See `setDrips` for more details.
+    /// @param userId The user ID
     function setDrips(
-        uint256 account,
+        uint256 userId,
         uint64 lastUpdate,
         uint128 lastBalance,
         DripsReceiver[] memory currReceivers,
@@ -67,7 +66,7 @@ contract EthDripsHub is ManagedDripsHub {
     ) public payable whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _setDrips(
-                _userOrAccount(msg.sender, account),
+                userId,
                 ASSET_ID,
                 lastUpdate,
                 lastBalance,
@@ -91,16 +90,16 @@ contract EthDripsHub is ManagedDripsHub {
     /// The funds to be given must be the value of the message.
     /// @param receiver The receiver
     function give(address receiver) public payable whenNotPaused {
-        _give(_userOrAccount(msg.sender), receiver, ASSET_ID, uint128(msg.value));
+        _give(calcUserId(msg.sender), receiver, ASSET_ID, uint128(msg.value));
     }
 
-    /// @notice Gives funds from the account of the `msg.sender` to the receiver.
+    /// @notice Gives funds from the user to the receiver.
     /// The receiver can collect them immediately.
     /// The funds to be given must be the value of the message.
-    /// @param account The user's account
+    /// @param userId The user ID.
     /// @param receiver The receiver
-    function give(uint256 account, address receiver) public payable whenNotPaused {
-        _give(_userOrAccount(msg.sender, account), receiver, ASSET_ID, uint128(msg.value));
+    function give(uint256 userId, address receiver) public payable whenNotPaused {
+        _give(userId, receiver, ASSET_ID, uint128(msg.value));
     }
 
     /// @notice Sets user splits configuration.

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -45,6 +45,14 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
         _managedDripsHubStorage().paused = true;
     }
 
+    /// @notice Creates an account.
+    /// Assigns it an ID and lets its owner perform actions on behalf of all its sub-accounts.
+    /// Multiple accounts can be registered for a single address, it will own all of them.
+    /// @return accountId The new account ID.
+    function createAccount(address owner) public override whenNotPaused returns (uint32 accountId) {
+        return super.createAccount(owner);
+    }
+
     /// @notice Collects all received funds available for the user
     /// and transfers them out of the drips hub contract to that user's wallet.
     /// @param assetId The used asset ID

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -677,4 +677,13 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         receiveDrips(receiver1, dripsHub.cycleSecs(), 1);
         receiveDrips(receiver2, dripsHub.cycleSecs() * 2, 1);
     }
+
+    function testCreateAccount() public {
+        address owner = address(0x1234);
+        uint32 accountId = dripsHub.nextAccountId();
+        assertEq(address(0), dripsHub.accountOwner(accountId), "Invalid nonexistent account owner");
+        assertEq(accountId, dripsHub.createAccount(owner), "Invalid assigned account ID");
+        assertEq(owner, dripsHub.accountOwner(accountId), "Invalid account owner");
+        assertEq(accountId + 1, dripsHub.nextAccountId(), "Invalid next account ID");
+    }
 }

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -42,7 +42,7 @@ abstract contract DripsHubUser {
     ) public virtual;
 
     function give(
-        uint256 account,
+        uint256 userId,
         address receiver,
         uint256 assetId,
         uint128 amt
@@ -116,8 +116,8 @@ abstract contract DripsHubUser {
         return dripsHub.dripsHash(address(this), assetId);
     }
 
-    function dripsHash(uint256 account, uint256 assetId) public view returns (bytes32 weightsHash) {
-        return dripsHub.dripsHash(address(this), account, assetId);
+    function dripsHash(uint256 userId, uint256 assetId) public view returns (bytes32 weightsHash) {
+        return dripsHub.dripsHash(userId, assetId);
     }
 
     function hashSplits(SplitsReceiver[] calldata receivers) public view returns (bytes32) {
@@ -194,7 +194,7 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
     }
 
     function setDrips(
-        uint256 account,
+        uint256 userId,
         uint256 assetId,
         uint64 lastUpdate,
         uint128 lastBalance,
@@ -206,7 +206,7 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
             IERC20(address(uint160(assetId))).approve(address(dripsHub), uint128(balanceDelta));
         return
             dripsHub.setDrips(
-                account,
+                userId,
                 assetId,
                 lastUpdate,
                 lastBalance,
@@ -226,13 +226,13 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
     }
 
     function give(
-        uint256 account,
+        uint256 userId,
         address receiver,
         uint256 assetId,
         uint128 amt
     ) public override {
         IERC20(address(uint160(assetId))).approve(address(dripsHub), amt);
-        dripsHub.give(account, receiver, assetId, amt);
+        dripsHub.give(userId, receiver, assetId, amt);
     }
 
     function setSplits(SplitsReceiver[] calldata receivers) public override {
@@ -278,7 +278,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
     }
 
     function setDrips(
-        uint256 account,
+        uint256 userId,
         uint256 assetId,
         uint64 lastUpdate,
         uint128 lastBalance,
@@ -291,7 +291,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
         uint128 reduceBalance = balanceDelta < 0 ? uint128(-balanceDelta) : 0;
         return
             dripsHub.setDrips{value: value}(
-                account,
+                userId,
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -310,13 +310,13 @@ contract EthDripsHubUser is ManagedDripsHubUser {
     }
 
     function give(
-        uint256 account,
+        uint256 userId,
         address receiver,
         uint256 assetId,
         uint128 amt
     ) public override {
         assetId;
-        dripsHub.give{value: amt}(account, receiver);
+        dripsHub.give{value: amt}(userId, receiver);
     }
 
     function setSplits(SplitsReceiver[] calldata receivers) public override {

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -184,4 +184,13 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
             assertEq(reason, ERROR_PAUSED, "Invalid setSplits revert reason");
         }
     }
+
+    function testCreateAccountCanBePaused() public {
+        admin.pause();
+        try dripsHub.createAccount(address(0x1234)) {
+            assertTrue(false, "CreateAccount hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, ERROR_PAUSED, "Invalid createAccount revert reason");
+        }
+    }
 }


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/98, blocked by https://github.com/radicle-dev/radicle-drips-hub/pull/111.

Adds the notion of a `userId` composed of the `account` and `subAccount`. Replaces all usage of accounts (address + uint256) with the new userId (uint256). It's been used for the user identification only in 2 functions: in `setDrips` (only the sender) and `give` (only the giver).

Temporarily adds the special account 0, which allows controlling sub-account equal to `msg.sender` without account creation. This is needed so we can keep the old API implicitly using `msg.sender` to identify the users, e.g. in `function give(address receiver, uint128 amt)`. This special case can be dropped when we switch the whole API to `userId` and outsource the EOA API to a separate contract.