### PR TITLE
Receiver user IDs

### DIFF
--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -84,7 +84,7 @@ contract DaiDripsHub is ERC20DripsHub {
     /// These parameters will be passed to the Dai contract by this function.
     /// @param permitArgs The Dai permission arguments.
     function giveAndPermit(
-        address receiver,
+        uint256 receiver,
         uint128 amt,
         PermitArgs calldata permitArgs
     ) public whenNotPaused {
@@ -101,7 +101,7 @@ contract DaiDripsHub is ERC20DripsHub {
     /// @param permitArgs The Dai permission arguments.
     function giveAndPermit(
         uint256 account,
-        address receiver,
+        uint256 receiver,
         uint128 amt,
         PermitArgs calldata permitArgs
     ) public whenNotPaused {

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -134,10 +134,10 @@ abstract contract DripsHub {
 
     /// @notice Emitted when funds are given from the user to the receiver.
     /// @param userId The user ID
-    /// @param receiver The receiver
+    /// @param receiver The receiver user ID
     /// @param assetId The used asset ID
     /// @param amt The given amount
-    event Given(uint256 indexed userId, address indexed receiver, uint256 assetId, uint128 amt);
+    event Given(uint256 indexed userId, uint256 indexed receiver, uint256 assetId, uint128 amt);
 
     struct DripsHubStorage {
         /// @notice User drips states.
@@ -470,11 +470,11 @@ abstract contract DripsHub {
     /// @param amt The given amount
     function _give(
         uint256 userId,
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) internal onlyAccountOwner(userId) {
-        _dripsHubStorage().splitsStates[calcUserId(receiver)].balances[assetId].unsplit += amt;
+        _dripsHubStorage().splitsStates[receiver].balances[assetId].unsplit += amt;
         emit Given(userId, receiver, assetId, amt);
         _transfer(assetId, -int128(amt));
     }

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -86,11 +86,11 @@ contract ERC20DripsHub is ManagedDripsHub {
     /// @notice Gives funds from the `msg.sender` to the receiver.
     /// The receiver can collect them immediately.
     /// Transfers the funds to be given from the sender's wallet to the drips hub contract.
-    /// @param receiver The receiver
+    /// @param receiver The receiver user ID
     /// @param assetId The used asset ID
     /// @param amt The given amount
     function give(
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public whenNotPaused {
@@ -101,12 +101,12 @@ contract ERC20DripsHub is ManagedDripsHub {
     /// The receiver can collect them immediately.
     /// Transfers the funds to be given from the sender's wallet to the drips hub contract.
     /// @param userId The user ID
-    /// @param receiver The receiver
+    /// @param receiver The receiver user ID
     /// @param assetId The used asset ID
     /// @param amt The given amount
     function give(
         uint256 userId,
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public whenNotPaused {

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -88,8 +88,8 @@ contract EthDripsHub is ManagedDripsHub {
     /// @notice Gives funds from the `msg.sender` to the receiver.
     /// The receiver can collect them immediately.
     /// The funds to be given must be the value of the message.
-    /// @param receiver The receiver
-    function give(address receiver) public payable whenNotPaused {
+    /// @param receiver The receiver user ID
+    function give(uint256 receiver) public payable whenNotPaused {
         _give(calcUserId(msg.sender), receiver, ASSET_ID, uint128(msg.value));
     }
 
@@ -97,8 +97,8 @@ contract EthDripsHub is ManagedDripsHub {
     /// The receiver can collect them immediately.
     /// The funds to be given must be the value of the message.
     /// @param userId The user ID.
-    /// @param receiver The receiver
-    function give(uint256 userId, address receiver) public payable whenNotPaused {
+    /// @param receiver The receiver user ID
+    function give(uint256 userId, uint256 receiver) public payable whenNotPaused {
         _give(userId, receiver, ASSET_ID, uint128(msg.value));
     }
 

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -246,10 +246,10 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         DripsReceiver[] memory receiversGood = new DripsReceiver[](countMax);
         DripsReceiver[] memory receiversBad = new DripsReceiver[](countMax + 1);
         for (uint160 i = 0; i < countMax; i++) {
-            receiversGood[i] = DripsReceiver(address(i + 1), 1);
+            receiversGood[i] = DripsReceiver(i, 1);
             receiversBad[i] = receiversGood[i];
         }
-        receiversBad[countMax] = DripsReceiver(address(countMax + 1), 1);
+        receiversBad[countMax] = DripsReceiver(countMax, 1);
 
         setDrips(user, 0, 0, receiversGood);
         assertSetReceiversReverts(user, receiversBad, "Too many drips receivers");
@@ -276,7 +276,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertSetReceiversReverts(
             user,
             dripsReceivers(receiver2, 1, receiver1, 1),
-            "Drips receivers not sorted by address"
+            "Drips receivers not sorted by user ID"
         );
     }
 

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -714,7 +714,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
     }
 
     function testGiveRevertsWhenNotAccountOwner() public {
-        try user1.give(calcUserId(dripsHub.nextAccountId(), 0), address(user2), defaultAsset, 1) {
+        try user1.give(calcUserId(dripsHub.nextAccountId(), 0), 0, defaultAsset, 1) {
             assertTrue(false, "Give hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_NOT_OWNER, "Invalid give revert reason");

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -422,10 +422,10 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         SplitsReceiver[] memory receiversGood = new SplitsReceiver[](countMax);
         SplitsReceiver[] memory receiversBad = new SplitsReceiver[](countMax + 1);
         for (uint160 i = 0; i < countMax; i++) {
-            receiversGood[i] = SplitsReceiver(address(i + 1), 1);
+            receiversGood[i] = SplitsReceiver(i, 1);
             receiversBad[i] = receiversGood[i];
         }
-        receiversBad[countMax] = SplitsReceiver(address(countMax + 1), 1);
+        receiversBad[countMax] = SplitsReceiver(countMax, 1);
 
         setSplits(user, receiversGood);
         assertSetSplitsReverts(user, receiversBad, "Too many splits receivers");
@@ -453,7 +453,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         assertSetSplitsReverts(
             user,
             splitsReceivers(receiver2, 1, receiver1, 1),
-            "Splits receivers not sorted by address"
+            "Splits receivers not sorted by user ID"
         );
     }
 

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -36,14 +36,14 @@ abstract contract DripsHubUser {
     ) public virtual returns (uint128 newBalance, int128 realBalanceDelta);
 
     function give(
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public virtual;
 
     function give(
         uint256 userId,
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public virtual;
@@ -217,7 +217,7 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
     }
 
     function give(
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public override {
@@ -227,7 +227,7 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
 
     function give(
         uint256 userId,
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public override {
@@ -301,7 +301,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
     }
 
     function give(
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public override {
@@ -311,7 +311,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
 
     function give(
         uint256 userId,
-        address receiver,
+        uint256 receiver,
         uint256 assetId,
         uint128 amt
     ) public override {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -386,11 +386,11 @@ abstract contract DripsHubUserUtils is DSTest {
 
     function splitsReceivers(DripsHubUser user, uint32 weight)
         internal
-        pure
+        view
         returns (SplitsReceiver[] memory list)
     {
         list = new SplitsReceiver[](1);
-        list[0] = SplitsReceiver(address(user), weight);
+        list[0] = SplitsReceiver(calcUserId(user), weight);
     }
 
     function splitsReceivers(
@@ -398,10 +398,10 @@ abstract contract DripsHubUserUtils is DSTest {
         uint32 weight1,
         DripsHubUser user2,
         uint32 weight2
-    ) internal pure returns (SplitsReceiver[] memory list) {
+    ) internal view returns (SplitsReceiver[] memory list) {
         list = new SplitsReceiver[](2);
-        list[0] = SplitsReceiver(address(user1), weight1);
-        list[1] = SplitsReceiver(address(user2), weight2);
+        list[0] = SplitsReceiver(calcUserId(user1), weight1);
+        list[1] = SplitsReceiver(calcUserId(user2), weight2);
     }
 
     function setSplits(DripsHubUser user, SplitsReceiver[] memory newReceivers) internal {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -358,7 +358,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint256 expectedBalance = uint256(user.balance(asset) - amt);
         uint128 expectedCollectable = totalCollectableAll(asset, receiver) + amt;
 
-        user.give(address(receiver), asset, amt);
+        user.give(calcUserId(receiver), asset, amt);
 
         assertBalance(asset, user, expectedBalance);
         assertTotalCollectableAll(asset, receiver, expectedCollectable);
@@ -374,7 +374,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint256 expectedBalance = uint256(user.balance(defaultAsset) - amt);
         uint128 expectedCollectable = totalCollectableAll(defaultAsset, receiver) + amt;
 
-        user.give(calcUserId(account, subAccount), address(receiver), defaultAsset, amt);
+        user.give(calcUserId(account, subAccount), calcUserId(receiver), defaultAsset, amt);
 
         assertBalance(defaultAsset, user, expectedBalance);
         assertTotalCollectableAll(defaultAsset, receiver, expectedCollectable);

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -152,11 +152,11 @@ abstract contract DripsHubUserUtils is DSTest {
 
     function dripsReceivers(DripsHubUser user, uint128 amtPerSec)
         internal
-        pure
+        view
         returns (DripsReceiver[] memory list)
     {
         list = new DripsReceiver[](1);
-        list[0] = DripsReceiver(address(user), amtPerSec);
+        list[0] = DripsReceiver(calcUserId(user), amtPerSec);
     }
 
     function dripsReceivers(
@@ -164,10 +164,10 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 amtPerSec1,
         DripsHubUser user2,
         uint128 amtPerSec2
-    ) internal pure returns (DripsReceiver[] memory list) {
+    ) internal view returns (DripsReceiver[] memory list) {
         list = new DripsReceiver[](2);
-        list[0] = DripsReceiver(address(user1), amtPerSec1);
-        list[1] = DripsReceiver(address(user2), amtPerSec2);
+        list[0] = DripsReceiver(calcUserId(user1), amtPerSec1);
+        list[1] = DripsReceiver(calcUserId(user2), amtPerSec2);
     }
 
     function setDrips(

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -160,7 +160,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testGiveCanBePaused() public {
         admin.pause();
-        try admin.give(address(user), defaultAsset, 1) {
+        try admin.give(0, defaultAsset, 1) {
             assertTrue(false, "Give hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid give revert reason");
@@ -169,7 +169,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testGiveFromAccountCanBePaused() public {
         admin.pause();
-        try admin.give(0, address(user), defaultAsset, 1) {
+        try admin.give(0, 0, defaultAsset, 1) {
             assertTrue(false, "Give hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid giveFrom revert reason");


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/98, blocked by https://github.com/radicle-dev/radicle-drips-hub/pull/112.

Switches the receiver configurations from addresses to user IDs for `setDrips`, `setSplits` and `give`. Now it's possible to support any sub-account, but only theoretically, there is still no way to collect for any sub-account, that'll be implemented in the upcoming PRs.