### PR TITLE
Sender user IDs

### DIFF
--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -57,22 +57,6 @@ contract DaiDripsHub is ERC20DripsHub {
             );
     }
 
-    /// @notice Gives funds from the `msg.sender` to the receiver
-    /// and permits spending sender's Dai by the drips hub.
-    /// This function is an extension of `give`, see its documentation for more details.
-    ///
-    /// The user must sign a Dai permission document allowing the drips hub to spend their funds.
-    /// These parameters will be passed to the Dai contract by this function.
-    /// @param permitArgs The Dai permission arguments.
-    function giveAndPermit(
-        uint256 receiver,
-        uint128 amt,
-        PermitArgs calldata permitArgs
-    ) public whenNotPaused {
-        _permit(permitArgs);
-        give(receiver, uint160(address(dai)), amt);
-    }
-
     /// @notice Gives funds from the account of the `msg.sender` to the receiver
     /// and permits spending sender's Dai by the drips hub.
     /// This function is an extension of `give` see its documentation for more details.

--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -28,7 +28,7 @@ contract DaiDripsHub is ERC20DripsHub {
         dai = _dai;
     }
 
-    /// @notice Sets the drips configuration of the `msg.sender`
+    /// @notice Sets the drips configuration of an account of the `msg.sender`
     /// and permits spending their Dai by the drips hub.
     /// This function is an extension of `setDrips`, see its documentation for more details.
     ///
@@ -36,6 +36,7 @@ contract DaiDripsHub is ERC20DripsHub {
     /// These parameters will be passed to the Dai contract by this function.
     /// @param permitArgs The Dai permission arguments.
     function setDripsAndPermit(
+        uint256 userId,
         uint64 lastUpdate,
         uint128 lastBalance,
         DripsReceiver[] memory currReceivers,
@@ -46,6 +47,7 @@ contract DaiDripsHub is ERC20DripsHub {
         _permit(permitArgs);
         return
             setDrips(
+                userId,
                 uint160(address(dai)),
                 lastUpdate,
                 lastBalance,
@@ -53,27 +55,6 @@ contract DaiDripsHub is ERC20DripsHub {
                 balanceDelta,
                 newReceivers
             );
-    }
-
-    /// @notice Sets the drips configuration of an account of the `msg.sender`
-    /// and permits spending their Dai by the drips hub.
-    /// This function is an extension of `setDrips`, see its documentation for more details.
-    ///
-    /// The user must sign a Dai permission document allowing the drips hub to spend their funds.
-    /// These parameters will be passed to the Dai contract by this function.
-    /// @param permitArgs The Dai permission arguments.
-    function setDripsAndPermit(
-        uint256 account,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] memory currReceivers,
-        int128 balanceDelta,
-        DripsReceiver[] memory newReceivers,
-        PermitArgs calldata permitArgs
-    ) public whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
-        _permit(permitArgs);
-        return
-            setDrips(account, lastUpdate, lastBalance, currReceivers, balanceDelta, newReceivers);
     }
 
     /// @notice Gives funds from the `msg.sender` to the receiver

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -479,14 +479,6 @@ abstract contract DripsHub {
         _transfer(assetId, -int128(amt));
     }
 
-    /// @notice Current user's drips hash, see `hashDrips`.
-    /// @param user The user
-    /// @param assetId The used asset ID
-    /// @return currDripsHash The current user's drips hash
-    function dripsHash(address user, uint256 assetId) public view returns (bytes32 currDripsHash) {
-        return dripsHash(calcUserId(user), assetId);
-    }
-
     /// @notice Current user drips hash, see `hashDrips`.
     /// @param userId The user ID
     /// @param assetId The used asset ID

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -98,7 +98,7 @@ abstract contract DripsHub {
     /// @notice Emitted when the user's splits are updated.
     /// @param user The user
     /// @param receivers The list of the user's splits receivers.
-    event SplitsUpdated(address indexed user, SplitsReceiver[] receivers);
+    event SplitsUpdated(uint256 indexed user, SplitsReceiver[] receivers);
 
     /// @notice Emitted when a user collects funds
     /// @param user The user
@@ -776,15 +776,18 @@ abstract contract DripsHub {
     }
 
     /// @notice Sets user splits configuration.
-    /// @param user The user
+    /// @param userId The user ID
     /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    function _setSplits(address user, SplitsReceiver[] memory receivers) internal {
+    function _setSplits(uint256 userId, SplitsReceiver[] memory receivers)
+        internal
+        onlyAccountOwner(userId)
+    {
         _assertSplitsValid(receivers);
-        _dripsHubStorage().splitsStates[calcUserId(user)].splitsHash = hashSplits(receivers);
-        emit SplitsUpdated(user, receivers);
+        _dripsHubStorage().splitsStates[userId].splitsHash = hashSplits(receivers);
+        emit SplitsUpdated(userId, receivers);
     }
 
     /// @notice Validates a list of splits receivers
@@ -809,10 +812,10 @@ abstract contract DripsHub {
     }
 
     /// @notice Current user's splits hash, see `hashSplits`.
-    /// @param user The user
+    /// @param userId The user ID
     /// @return currSplitsHash The current user's splits hash
-    function splitsHash(address user) public view returns (bytes32 currSplitsHash) {
-        return _dripsHubStorage().splitsStates[calcUserId(user)].splitsHash;
+    function splitsHash(uint256 userId) public view returns (bytes32 currSplitsHash) {
+        return _dripsHubStorage().splitsStates[userId].splitsHash;
     }
 
     /// @notice Asserts that the list of splits receivers is the user's currently used one.

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -45,20 +45,6 @@ contract ERC20DripsHub is ManagedDripsHub {
             );
     }
 
-    /// @notice Gives funds from the `msg.sender` to the receiver.
-    /// The receiver can collect them immediately.
-    /// Transfers the funds to be given from the sender's wallet to the drips hub contract.
-    /// @param receiver The receiver user ID
-    /// @param assetId The used asset ID
-    /// @param amt The given amount
-    function give(
-        uint256 receiver,
-        uint256 assetId,
-        uint128 amt
-    ) public whenNotPaused {
-        _give(calcUserId(msg.sender), receiver, assetId, amt);
-    }
-
     /// @notice Gives funds from the user to the receiver.
     /// The receiver can collect them immediately.
     /// Transfers the funds to be given from the sender's wallet to the drips hub contract.

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -22,44 +22,6 @@ contract ERC20DripsHub is ManagedDripsHub {
         reserve = _reserve;
     }
 
-    /// @notice Sets the drips configuration of the `msg.sender`.
-    /// Transfers funds to or from the sender to fulfill the update of the drips balance.
-    /// The sender must first grant the contract a sufficient allowance.
-    /// @param assetId The used asset ID
-    /// @param lastUpdate The timestamp of the last drips update of the `msg.sender`.
-    /// If this is the first update, pass zero.
-    /// @param lastBalance The drips balance after the last drips update of the `msg.sender`.
-    /// If this is the first update, pass zero.
-    /// @param currReceivers The list of the drips receivers set in the last drips update
-    /// of the `msg.sender`.
-    /// If this is the first update, pass an empty array.
-    /// @param balanceDelta The drips balance change to be applied.
-    /// Positive to add funds to the drips balance, negative to remove them.
-    /// @param newReceivers The list of the drips receivers of the `msg.sender` to be set.
-    /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
-    /// @return newBalance The new drips balance of the `msg.sender`.
-    /// Pass it as `lastBalance` when updating that user or the account for the next time.
-    /// @return realBalanceDelta The actually applied drips balance change.
-    function setDrips(
-        uint256 assetId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] memory currReceivers,
-        int128 balanceDelta,
-        DripsReceiver[] memory newReceivers
-    ) public whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
-        return
-            _setDrips(
-                calcUserId(msg.sender),
-                assetId,
-                lastUpdate,
-                lastBalance,
-                currReceivers,
-                balanceDelta,
-                newReceivers
-            );
-    }
-
     /// @notice Sets the drips configuration of the user. See `setDrips` for more details.
     /// @param userId The user ID
     function setDrips(

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -114,12 +114,13 @@ contract ERC20DripsHub is ManagedDripsHub {
     }
 
     /// @notice Sets user splits configuration.
+    /// @param userId The user ID
     /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    function setSplits(SplitsReceiver[] memory receivers) public whenNotPaused {
-        _setSplits(msg.sender, receivers);
+    function setSplits(uint256 userId, SplitsReceiver[] memory receivers) public whenNotPaused {
+        _setSplits(userId, receivers);
     }
 
     function _transfer(uint256 assetId, int128 amt) internal override {

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -18,42 +18,6 @@ contract EthDripsHub is ManagedDripsHub {
         return;
     }
 
-    /// @notice Sets the drips configuration of the `msg.sender`.
-    /// Increases the drips balance with the value of the message.
-    /// Transfers the reduced drips balance to the `msg.sender`.
-    /// @param lastUpdate The timestamp of the last drips update of the `msg.sender`.
-    /// If this is the first update, pass zero.
-    /// @param lastBalance The drips balance after the last drips update of the `msg.sender`.
-    /// If this is the first update, pass zero.
-    /// @param currReceivers The list of the drips receivers set in the last drips update
-    /// of the `msg.sender`.
-    /// If this is the first update, pass an empty array.
-    /// @param reduceBalance The drips balance reduction to be applied.
-    /// If more than 0, the message value must be 0.
-    /// @param newReceivers The list of the drips receivers of the `msg.sender` to be set.
-    /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
-    /// @return newBalance The new drips balance of the `msg.sender`.
-    /// Pass it as `lastBalance` when updating that user or the account for the next time.
-    /// @return realBalanceDelta The actually applied drips balance change.
-    function setDrips(
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] memory currReceivers,
-        uint128 reduceBalance,
-        DripsReceiver[] memory newReceivers
-    ) public payable whenNotPaused returns (uint128 newBalance, int128 realBalanceDelta) {
-        return
-            _setDrips(
-                calcUserId(msg.sender),
-                ASSET_ID,
-                lastUpdate,
-                lastBalance,
-                currReceivers,
-                _balanceDelta(reduceBalance),
-                newReceivers
-            );
-    }
-
     /// @notice Sets the drips configuration of the user. See `setDrips` for more details.
     /// @param userId The user ID
     function setDrips(

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -49,14 +49,6 @@ contract EthDripsHub is ManagedDripsHub {
         return -int128(reduceBalance);
     }
 
-    /// @notice Gives funds from the `msg.sender` to the receiver.
-    /// The receiver can collect them immediately.
-    /// The funds to be given must be the value of the message.
-    /// @param receiver The receiver user ID
-    function give(uint256 receiver) public payable whenNotPaused {
-        _give(calcUserId(msg.sender), receiver, ASSET_ID, uint128(msg.value));
-    }
-
     /// @notice Gives funds from the user to the receiver.
     /// The receiver can collect them immediately.
     /// The funds to be given must be the value of the message.

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -103,12 +103,13 @@ contract EthDripsHub is ManagedDripsHub {
     }
 
     /// @notice Sets user splits configuration.
+    /// @param userId The user ID.
     /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    function setSplits(SplitsReceiver[] memory receivers) public whenNotPaused {
-        _setSplits(msg.sender, receivers);
+    function setSplits(uint256 userId, SplitsReceiver[] memory receivers) public whenNotPaused {
+        _setSplits(userId, receivers);
     }
 
     function _transfer(uint256 assetId, int128 amt) internal override {

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -720,4 +720,12 @@ abstract contract DripsHubTest is DripsHubUserUtils {
             assertEq(reason, ERROR_NOT_OWNER, "Invalid give revert reason");
         }
     }
+
+    function testSetSplitsRevertsWhenNotAccountOwner() public {
+        try user.setSplits(calcUserId(dripsHub.nextAccountId(), 0), splitsReceivers()) {
+            assertTrue(false, "SetSplits hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, ERROR_NOT_OWNER, "Invalid setSplits revert reason");
+        }
+    }
 }

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -345,6 +345,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         // User had 4 second paying 1 per second
         uint256 expectedBalance = user.balance(defaultAsset) + 6;
         (uint128 newBalance, int128 realBalanceDelta) = user.setDrips(
+            calcUserId(user),
             defaultAsset,
             lastUpdate,
             10,

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -27,12 +27,6 @@ abstract contract DripsHubUser {
     ) public virtual returns (uint128 newBalance, int128 realBalanceDelta);
 
     function give(
-        uint256 receiver,
-        uint256 assetId,
-        uint128 amt
-    ) public virtual;
-
-    function give(
         uint256 userId,
         uint256 receiver,
         uint256 assetId,
@@ -183,15 +177,6 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
     }
 
     function give(
-        uint256 receiver,
-        uint256 assetId,
-        uint128 amt
-    ) public override {
-        IERC20(address(uint160(assetId))).approve(address(dripsHub), amt);
-        dripsHub.give(receiver, assetId, amt);
-    }
-
-    function give(
         uint256 userId,
         uint256 receiver,
         uint256 assetId,
@@ -243,15 +228,6 @@ contract EthDripsHubUser is ManagedDripsHubUser {
                 reduceBalance,
                 newReceivers
             );
-    }
-
-    function give(
-        uint256 receiver,
-        uint256 assetId,
-        uint128 amt
-    ) public override {
-        assetId;
-        dripsHub.give{value: amt}(receiver);
     }
 
     function give(

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -48,7 +48,7 @@ abstract contract DripsHubUser {
         uint128 amt
     ) public virtual;
 
-    function setSplits(SplitsReceiver[] calldata receivers) public virtual;
+    function setSplits(uint256 userId, SplitsReceiver[] calldata receivers) public virtual;
 
     function collectAll(uint256 assetId, SplitsReceiver[] calldata currReceivers)
         public
@@ -124,8 +124,8 @@ abstract contract DripsHubUser {
         return dripsHub.hashSplits(receivers);
     }
 
-    function splitsHash() public view returns (bytes32) {
-        return dripsHub.splitsHash(address(this));
+    function splitsHash(uint256 userId) public view returns (bytes32) {
+        return dripsHub.splitsHash(userId);
     }
 }
 
@@ -235,8 +235,8 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
         dripsHub.give(userId, receiver, assetId, amt);
     }
 
-    function setSplits(SplitsReceiver[] calldata receivers) public override {
-        dripsHub.setSplits(receivers);
+    function setSplits(uint256 userId, SplitsReceiver[] calldata receivers) public override {
+        dripsHub.setSplits(userId, receivers);
     }
 }
 
@@ -319,7 +319,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
         dripsHub.give{value: amt}(userId, receiver);
     }
 
-    function setSplits(SplitsReceiver[] calldata receivers) public override {
-        dripsHub.setSplits(receivers);
+    function setSplits(uint256 userId, SplitsReceiver[] calldata receivers) public override {
+        dripsHub.setSplits(userId, receivers);
     }
 }

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -17,16 +17,7 @@ abstract contract DripsHubUser {
     function balance(uint256 assetId) public view virtual returns (uint256);
 
     function setDrips(
-        uint256 assetId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] calldata currReceivers,
-        int128 balanceDelta,
-        DripsReceiver[] calldata newReceivers
-    ) public virtual returns (uint128 newBalance, int128 realBalanceDelta);
-
-    function setDrips(
-        uint256 account,
+        uint256 userId,
         uint256 assetId,
         uint64 lastUpdate,
         uint128 lastBalance,
@@ -112,10 +103,6 @@ abstract contract DripsHubUser {
         return dripsHub.hashDrips(lastUpdate, lastBalance, receivers);
     }
 
-    function dripsHash(uint256 assetId) public view returns (bytes32) {
-        return dripsHub.dripsHash(address(this), assetId);
-    }
-
     function dripsHash(uint256 userId, uint256 assetId) public view returns (bytes32 weightsHash) {
         return dripsHub.dripsHash(userId, assetId);
     }
@@ -170,27 +157,6 @@ contract ERC20DripsHubUser is ManagedDripsHubUser {
 
     function balance(uint256 assetId) public view override returns (uint256) {
         return IERC20(address(uint160(assetId))).balanceOf(address(this));
-    }
-
-    function setDrips(
-        uint256 assetId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] calldata currReceivers,
-        int128 balanceDelta,
-        DripsReceiver[] calldata newReceivers
-    ) public override returns (uint128 newBalance, int128 realBalanceDelta) {
-        if (balanceDelta > 0)
-            IERC20(address(uint160(assetId))).approve(address(dripsHub), uint128(balanceDelta));
-        return
-            dripsHub.setDrips(
-                assetId,
-                lastUpdate,
-                lastBalance,
-                currReceivers,
-                balanceDelta,
-                newReceivers
-            );
     }
 
     function setDrips(
@@ -257,27 +223,6 @@ contract EthDripsHubUser is ManagedDripsHubUser {
     }
 
     function setDrips(
-        uint256 assetId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        DripsReceiver[] calldata currReceivers,
-        int128 balanceDelta,
-        DripsReceiver[] calldata newReceivers
-    ) public override returns (uint128 newBalance, int128 realBalanceDelta) {
-        assetId;
-        uint256 value = balanceDelta > 0 ? uint128(balanceDelta) : 0;
-        uint128 reduceBalance = balanceDelta < 0 ? uint128(uint136(-int136(balanceDelta))) : 0;
-        return
-            dripsHub.setDrips{value: value}(
-                lastUpdate,
-                lastBalance,
-                currReceivers,
-                reduceBalance,
-                newReceivers
-            );
-    }
-
-    function setDrips(
         uint256 userId,
         uint256 assetId,
         uint64 lastUpdate,
@@ -288,7 +233,7 @@ contract EthDripsHubUser is ManagedDripsHubUser {
     ) public override returns (uint128 newBalance, int128 realBalanceDelta) {
         assetId;
         uint256 value = balanceDelta > 0 ? uint128(balanceDelta) : 0;
-        uint128 reduceBalance = balanceDelta < 0 ? uint128(-balanceDelta) : 0;
+        uint128 reduceBalance = balanceDelta < 0 ? uint128(uint136(-int136(balanceDelta))) : 0;
         return
             dripsHub.setDrips{value: value}(
                 userId,

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -408,7 +408,7 @@ abstract contract DripsHubUserUtils is DSTest {
         SplitsReceiver[] memory curr = getCurrSplitsReceivers(user);
         assertSplits(user, curr);
 
-        user.setSplits(newReceivers);
+        user.setSplits(calcUserId(user), newReceivers);
 
         setCurrSplitsReceivers(user, newReceivers);
         assertSplits(user, newReceivers);
@@ -421,7 +421,7 @@ abstract contract DripsHubUserUtils is DSTest {
     ) internal {
         SplitsReceiver[] memory curr = getCurrSplitsReceivers(user);
         assertSplits(user, curr);
-        try user.setSplits(newReceivers) {
+        try user.setSplits(calcUserId(user), newReceivers) {
             assertTrue(false, "setSplits hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, expectedReason, "Invalid setSplits revert reason");
@@ -429,7 +429,7 @@ abstract contract DripsHubUserUtils is DSTest {
     }
 
     function assertSplits(DripsHubUser user, SplitsReceiver[] memory expectedReceivers) internal {
-        bytes32 actual = user.splitsHash();
+        bytes32 actual = user.splitsHash(calcUserId(user));
         bytes32 expected = user.hashSplits(expectedReceivers);
         assertEq(actual, expected, "Invalid splits hash");
     }

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -347,7 +347,7 @@ abstract contract DripsHubUserUtils is DSTest {
         DripsHubUser receiver,
         uint128 amt
     ) internal {
-        give(defaultAsset, user, receiver, amt);
+        give(defaultAsset, user, calcUserId(user), receiver, amt);
     }
 
     function give(
@@ -356,13 +356,7 @@ abstract contract DripsHubUserUtils is DSTest {
         DripsHubUser receiver,
         uint128 amt
     ) internal {
-        uint256 expectedBalance = uint256(user.balance(asset) - amt);
-        uint128 expectedCollectable = totalCollectableAll(asset, receiver) + amt;
-
-        user.give(calcUserId(receiver), asset, amt);
-
-        assertBalance(asset, user, expectedBalance);
-        assertTotalCollectableAll(asset, receiver, expectedCollectable);
+        give(asset, user, calcUserId(user), receiver, amt);
     }
 
     function give(
@@ -372,13 +366,23 @@ abstract contract DripsHubUserUtils is DSTest {
         DripsHubUser receiver,
         uint128 amt
     ) internal {
-        uint256 expectedBalance = uint256(user.balance(defaultAsset) - amt);
-        uint128 expectedCollectable = totalCollectableAll(defaultAsset, receiver) + amt;
+        give(defaultAsset, user, calcUserId(account, subAccount), receiver, amt);
+    }
 
-        user.give(calcUserId(account, subAccount), calcUserId(receiver), defaultAsset, amt);
+    function give(
+        uint256 asset,
+        DripsHubUser user,
+        uint256 userId,
+        DripsHubUser receiver,
+        uint128 amt
+    ) internal {
+        uint256 expectedBalance = uint256(user.balance(asset) - amt);
+        uint128 expectedCollectable = totalCollectableAll(asset, receiver) + amt;
 
-        assertBalance(defaultAsset, user, expectedBalance);
-        assertTotalCollectableAll(defaultAsset, receiver, expectedCollectable);
+        user.give(userId, calcUserId(receiver), asset, amt);
+
+        assertBalance(asset, user, expectedBalance);
+        assertTotalCollectableAll(asset, receiver, expectedCollectable);
     }
 
     function splitsReceivers() internal pure returns (SplitsReceiver[] memory list) {

--- a/src/test/EthDripsHub.t.sol
+++ b/src/test/EthDripsHub.t.sol
@@ -27,7 +27,16 @@ contract EthDripsHubTest is ManagedDripsHubTest {
     }
 
     function testRevertsIfBalanceReductionAndValueNonZero() public {
-        try dripsHub.setDrips{value: 1}(0, 0, dripsReceivers(), 1, dripsReceivers()) {
+        try
+            dripsHub.setDrips{value: 1}(
+                calcUserId(address(this)),
+                0,
+                0,
+                dripsReceivers(),
+                1,
+                dripsReceivers()
+            )
+        {
             assertTrue(false, "Set drips hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -142,7 +142,17 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testSetDripsCanBePaused() public {
         admin.pause();
-        try admin.setDrips(defaultAsset, 0, 0, new DripsReceiver[](0), 1, new DripsReceiver[](0)) {
+        try
+            admin.setDrips(
+                calcUserId(admin),
+                defaultAsset,
+                0,
+                0,
+                new DripsReceiver[](0),
+                1,
+                new DripsReceiver[](0)
+            )
+        {
             assertTrue(false, "SetDrips hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid setDrips revert reason");
@@ -151,7 +161,17 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testSetDripsFromAccountCanBePaused() public {
         admin.pause();
-        try admin.setDrips(defaultAsset, 0, 0, new DripsReceiver[](0), 1, new DripsReceiver[](0)) {
+        try
+            admin.setDrips(
+                calcUserId(admin),
+                defaultAsset,
+                0,
+                0,
+                new DripsReceiver[](0),
+                1,
+                new DripsReceiver[](0)
+            )
+        {
             assertTrue(false, "SetDrips hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid setDrips revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -180,7 +180,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testGiveCanBePaused() public {
         admin.pause();
-        try admin.give(0, defaultAsset, 1) {
+        try admin.give(calcUserId(admin), 0, defaultAsset, 1) {
             assertTrue(false, "Give hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid give revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -178,7 +178,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testSetSplitsCanBePaused() public {
         admin.pause();
-        try admin.setSplits(new SplitsReceiver[](0)) {
+        try admin.setSplits(calcUserId(admin), new SplitsReceiver[](0)) {
             assertTrue(false, "SetSplits hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid setSplits revert reason");


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/98, blocked by https://github.com/radicle-dev/radicle-drips-hub/pull/113.

Switches the sender identification from implicit msg.sender to user ID. This means an API change for `setSplits` and dropping of msg.sender versions of `setDrips` and `give`.