### PR TITLE
Collectors user IDs

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -244,17 +244,16 @@ abstract contract DripsHub {
         returns (DripsHubStorage storage dripsHubStorage);
 
     /// @notice Returns amount of received funds available for collection for a user.
-    /// @param user The user
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collectedAmt The collected amount
     /// @return splitAmt The amount split to the user's splits receivers
     function collectableAll(
-        address user,
+        uint256 userId,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers
     ) public view returns (uint128 collectedAmt, uint128 splitAmt) {
-        uint256 userId = calcUserId(user);
         _assertCurrSplits(userId, currReceivers);
         SplitsBalance storage balance = _dripsHubStorage().splitsStates[userId].balances[assetId];
 
@@ -280,17 +279,17 @@ abstract contract DripsHub {
     }
 
     /// @notice Collects all received funds available for the user
-    /// and transfers them out of the drips hub contract to that user's wallet.
+    /// and transfers them out of the drips hub contract to msg.sender.
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collectedAmt The collected amount
     /// @return splitAmt The amount split to the user's splits receivers
-    function collectAll(uint256 assetId, SplitsReceiver[] memory currReceivers)
-        public
-        virtual
-        returns (uint128 collectedAmt, uint128 splitAmt)
-    {
-        uint256 userId = calcUserId(msg.sender);
+    function collectAll(
+        uint256 userId,
+        uint256 assetId,
+        SplitsReceiver[] memory currReceivers
+    ) public virtual returns (uint128 collectedAmt, uint128 splitAmt) {
         receiveDrips(userId, assetId, type(uint64).max);
         (, splitAmt) = split(userId, assetId, currReceivers);
         collectedAmt = collect(userId, assetId);
@@ -866,10 +865,6 @@ abstract contract DripsHub {
         ];
         amtDelta.thisCycle += int128(uint128(thisCycleSecs)) * amtPerSecDelta;
         amtDelta.nextCycle += int128(uint128(nextCycleSecs)) * amtPerSecDelta;
-    }
-
-    function calcUserId(address user) public pure returns (uint256) {
-        return uint160(user);
     }
 
     function _currTimestamp() internal view returns (uint64) {

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -299,15 +299,14 @@ abstract contract DripsHub {
     /// @notice Counts cycles from which drips can be collected.
     /// This function can be used to detect that there are
     /// too many cycles to analyze in a single transaction.
-    /// @param user The user
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @return cycles The number of cycles which can be flushed
-    function receivableDripsCycles(address user, uint256 assetId)
+    function receivableDripsCycles(uint256 userId, uint256 assetId)
         public
         view
         returns (uint64 cycles)
     {
-        uint256 userId = calcUserId(user);
         uint64 collectedCycle = _dripsHubStorage().dripsStates[userId][assetId].nextCollectedCycle;
         if (collectedCycle == 0) return 0;
         uint64 currFinishedCycle = _currTimestamp() / cycleSecs;
@@ -327,10 +326,10 @@ abstract contract DripsHub {
         uint256 assetId,
         uint64 maxCycles
     ) public view returns (uint128 receivableAmt, uint64 receivableCycles) {
-        uint64 allReceivableCycles = receivableDripsCycles(user, assetId);
+        uint256 userId = calcUserId(user);
+        uint64 allReceivableCycles = receivableDripsCycles(userId, assetId);
         uint64 receivedCycles = maxCycles < allReceivableCycles ? maxCycles : allReceivableCycles;
         receivableCycles = allReceivableCycles - receivedCycles;
-        uint256 userId = calcUserId(user);
         DripsState storage dripsState = _dripsHubStorage().dripsStates[userId][assetId];
         uint64 collectedCycle = dripsState.nextCollectedCycle;
         int128 cycleAmt = 0;
@@ -358,7 +357,7 @@ abstract contract DripsHub {
         uint64 maxCycles
     ) public virtual returns (uint128 receivedAmt, uint64 receivableCycles) {
         uint256 userId = calcUserId(user);
-        receivableCycles = receivableDripsCycles(user, assetId);
+        receivableCycles = receivableDripsCycles(userId, assetId);
         uint64 cycles = maxCycles < receivableCycles ? maxCycles : receivableCycles;
         receivableCycles -= cycles;
         receivedAmt = _receiveDripsInternal(userId, assetId, cycles);

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -102,11 +102,17 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     }
 
     /// @notice Collects user's received already split funds
-    /// and transfers them out of the drips hub contract to that user's wallet.
+    /// and transfers them out of the drips hub contract to msg.sender.
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @return amt The collected amount
-    function collect(uint256 assetId) public override whenNotPaused returns (uint128 amt) {
-        return super.collect(assetId);
+    function collect(uint256 userId, uint256 assetId)
+        public
+        override
+        whenNotPaused
+        returns (uint128 amt)
+    {
+        return super.collect(userId, assetId);
     }
 
     /// @notice Authorizes the contract upgrade. See `UUPSUpgradable` docs for more details.

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -54,18 +54,18 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     }
 
     /// @notice Collects all received funds available for the user
-    /// and transfers them out of the drips hub contract to that user's wallet.
+    /// and transfers them out of the drips hub contract to msg.sender.
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collectedAmt The collected amount
     /// @return splitAmt The amount split to the user's splits receivers
-    function collectAll(uint256 assetId, SplitsReceiver[] memory currReceivers)
-        public
-        override
-        whenNotPaused
-        returns (uint128 collectedAmt, uint128 splitAmt)
-    {
-        return super.collectAll(assetId, currReceivers);
+    function collectAll(
+        uint256 userId,
+        uint256 assetId,
+        SplitsReceiver[] memory currReceivers
+    ) public override whenNotPaused returns (uint128 collectedAmt, uint128 splitAmt) {
+        return super.collectAll(userId, assetId, currReceivers);
     }
 
     /// @notice Receive drips from uncollected cycles of the user.

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -71,7 +71,7 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     /// @notice Receive drips from uncollected cycles of the user.
     /// Received drips cycles won't need to be analyzed ever again.
     /// Calling this function does not collect but makes the funds ready to be split and collected.
-    /// @param user The user
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @param maxCycles The maximum number of received drips cycles.
     /// If too low, receiving will be cheap, but may not cover many cycles.
@@ -79,11 +79,11 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     /// @return receivedAmt The received amount
     /// @return receivableCycles The number of cycles which still can be received
     function receiveDrips(
-        address user,
+        uint256 userId,
         uint256 assetId,
         uint64 maxCycles
     ) public override whenNotPaused returns (uint128 receivedAmt, uint64 receivableCycles) {
-        return super.receiveDrips(user, assetId, maxCycles);
+        return super.receiveDrips(userId, assetId, maxCycles);
     }
 
     /// @notice Splits user's received but not split yet funds among receivers.

--- a/src/ManagedDripsHub.sol
+++ b/src/ManagedDripsHub.sol
@@ -87,18 +87,18 @@ abstract contract ManagedDripsHub is DripsHub, UUPSUpgradeable {
     }
 
     /// @notice Splits user's received but not split yet funds among receivers.
-    /// @param user The user
+    /// @param userId The user ID
     /// @param assetId The used asset ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @return collectableAmt The amount made collectable for the user
     /// on top of what was collectable before.
     /// @return splitAmt The amount split to the user's splits receivers
     function split(
-        address user,
+        uint256 userId,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers
     ) public override whenNotPaused returns (uint128 collectableAmt, uint128 splitAmt) {
-        return super.split(user, assetId, currReceivers);
+        return super.split(userId, assetId, currReceivers);
     }
 
     /// @notice Collects user's received already split funds

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -127,7 +127,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
 
     function testCollectAllRevertsIfInvalidCurrSplitsReceivers() public {
         setSplits(user, splitsReceivers(receiver, 1));
-        try user.collectAll(defaultAsset, splitsReceivers(receiver, 2)) {
+        try user.collectAll(calcUserId(user), defaultAsset, splitsReceivers(receiver, 2)) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Invalid current splits receivers", "Invalid collect revert reason");
@@ -150,7 +150,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
 
     function testCollectableAllRevertsIfInvalidCurrSplitsReceivers() public {
         setSplits(user, splitsReceivers(receiver, 1));
-        try user.collectableAll(defaultAsset, splitsReceivers(receiver, 2)) {
+        try user.collectableAll(calcUserId(user), defaultAsset, splitsReceivers(receiver, 2)) {
             assertTrue(false, "Collectable hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(
@@ -735,6 +735,20 @@ abstract contract DripsHubTest is DripsHubUserUtils {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_NOT_OWNER, "Invalid collect revert reason");
+        }
+    }
+
+    function testCollectAllRevertsWhenNotAccountOwner() public {
+        try
+            user.collectAll(
+                calcUserId(dripsHub.nextAccountId(), 0),
+                defaultAsset,
+                new SplitsReceiver[](0)
+            )
+        {
+            assertTrue(false, "CollectAll hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, ERROR_NOT_OWNER, "Invalid collectAll revert reason");
         }
     }
 }

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -624,7 +624,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
 
     function testSplitRevertsIfInvalidCurrSplitsReceivers() public {
         setSplits(user, splitsReceivers(receiver, 1));
-        try user.split(address(user), defaultAsset, splitsReceivers(receiver, 2)) {
+        try user.split(calcUserId(user), defaultAsset, splitsReceivers(receiver, 2)) {
             assertTrue(false, "Split hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Invalid current splits receivers", "Invalid split revert reason");
@@ -655,7 +655,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
 
         // Splitting 20
         (uint128 collectableAmt, uint128 splitAmt) = receiver1.split(
-            address(receiver1),
+            calcUserId(receiver1),
             defaultAsset,
             getCurrSplitsReceivers(receiver1)
         );
@@ -667,7 +667,7 @@ abstract contract DripsHubTest is DripsHubUserUtils {
 
         // Splitting 10 which has been split to receiver1 themselves in the previous step
         (collectableAmt, splitAmt) = receiver1.split(
-            address(receiver1),
+            calcUserId(receiver1),
             defaultAsset,
             getCurrSplitsReceivers(receiver1)
         );

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -729,4 +729,12 @@ abstract contract DripsHubTest is DripsHubUserUtils {
             assertEq(reason, ERROR_NOT_OWNER, "Invalid setSplits revert reason");
         }
     }
+
+    function testCollectRevertsWhenNotAccountOwner() public {
+        try user.collect(calcUserId(dripsHub.nextAccountId(), 0), defaultAsset) {
+            assertTrue(false, "Collect hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, ERROR_NOT_OWNER, "Invalid collect revert reason");
+        }
+    }
 }

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -81,12 +81,12 @@ abstract contract DripsHubUser {
         return dripsHub.split(user, assetId, currReceivers);
     }
 
-    function collectable(address user, uint256 assetId) public view returns (uint128 amt) {
-        return dripsHub.collectable(user, assetId);
+    function collectable(uint256 userId, uint256 assetId) public view returns (uint128 amt) {
+        return dripsHub.collectable(userId, assetId);
     }
 
-    function collect(uint256 assetId) public virtual returns (uint128 aamt) {
-        return dripsHub.collect(assetId);
+    function collect(uint256 userId, uint256 assetId) public virtual returns (uint128 aamt) {
+        return dripsHub.collect(userId, assetId);
     }
 
     function hashDrips(

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -35,19 +35,20 @@ abstract contract DripsHubUser {
 
     function setSplits(uint256 userId, SplitsReceiver[] calldata receivers) public virtual;
 
-    function collectAll(uint256 assetId, SplitsReceiver[] calldata currReceivers)
-        public
-        returns (uint128 collected, uint128 splitAmt)
-    {
-        return dripsHub.collectAll(assetId, currReceivers);
+    function collectAll(
+        uint256 userId,
+        uint256 assetId,
+        SplitsReceiver[] calldata currReceivers
+    ) public returns (uint128 collected, uint128 splitAmt) {
+        return dripsHub.collectAll(userId, assetId, currReceivers);
     }
 
-    function collectableAll(uint256 assetId, SplitsReceiver[] calldata currReceivers)
-        public
-        view
-        returns (uint128 collected, uint128 splitAmt)
-    {
-        return dripsHub.collectableAll(address(this), assetId, currReceivers);
+    function collectableAll(
+        uint256 userId,
+        uint256 assetId,
+        SplitsReceiver[] calldata currReceivers
+    ) public view returns (uint128 collected, uint128 splitAmt) {
+        return dripsHub.collectableAll(userId, assetId, currReceivers);
     }
 
     function receivableDripsCycles(uint256 userId, uint256 assetId)

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -58,19 +58,20 @@ abstract contract DripsHubUser {
         return dripsHub.receivableDripsCycles(userId, assetId);
     }
 
-    function receivableDrips(uint256 assetId, uint64 maxCycles)
-        public
-        view
-        returns (uint128 receivableAmt, uint64 receivableCycles)
-    {
-        return dripsHub.receivableDrips(address(this), assetId, maxCycles);
+    function receivableDrips(
+        uint256 userId,
+        uint256 assetId,
+        uint64 maxCycles
+    ) public view returns (uint128 receivableAmt, uint64 receivableCycles) {
+        return dripsHub.receivableDrips(userId, assetId, maxCycles);
     }
 
-    function receiveDrips(uint256 assetId, uint64 maxCycles)
-        public
-        returns (uint128 receivedAmt, uint64 receivableCycles)
-    {
-        return dripsHub.receiveDrips(address(this), assetId, maxCycles);
+    function receiveDrips(
+        uint256 userId,
+        uint256 assetId,
+        uint64 maxCycles
+    ) public returns (uint128 receivedAmt, uint64 receivableCycles) {
+        return dripsHub.receiveDrips(userId, assetId, maxCycles);
     }
 
     function splittable(uint256 userId, uint256 assetId) public view returns (uint128 amt) {

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -50,8 +50,12 @@ abstract contract DripsHubUser {
         return dripsHub.collectableAll(address(this), assetId, currReceivers);
     }
 
-    function receivableDripsCycles(uint256 assetId) public view returns (uint64 cycles) {
-        return dripsHub.receivableDripsCycles(address(this), assetId);
+    function receivableDripsCycles(uint256 userId, uint256 assetId)
+        public
+        view
+        returns (uint64 cycles)
+    {
+        return dripsHub.receivableDripsCycles(userId, assetId);
     }
 
     function receivableDrips(uint256 assetId, uint64 maxCycles)

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -69,16 +69,16 @@ abstract contract DripsHubUser {
         return dripsHub.receiveDrips(address(this), assetId, maxCycles);
     }
 
-    function splittable(address user, uint256 assetId) public view returns (uint128 amt) {
-        return dripsHub.splittable(user, assetId);
+    function splittable(uint256 userId, uint256 assetId) public view returns (uint128 amt) {
+        return dripsHub.splittable(userId, assetId);
     }
 
     function split(
-        address user,
+        uint256 userId,
         uint256 assetId,
         SplitsReceiver[] memory currReceivers
     ) public virtual returns (uint128 collectableAmt, uint128 splitAmt) {
-        return dripsHub.split(user, assetId, currReceivers);
+        return dripsHub.split(userId, assetId, currReceivers);
     }
 
     function collectable(uint256 userId, uint256 assetId) public view returns (uint128 amt) {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -602,7 +602,7 @@ abstract contract DripsHubUserUtils is DSTest {
         assertCollectable(user, expectedAmt);
         uint256 balanceBefore = user.balance(defaultAsset);
 
-        uint128 actualAmt = user.collect(defaultAsset);
+        uint128 actualAmt = user.collect(calcUserId(user), defaultAsset);
 
         assertEq(actualAmt, expectedAmt, "Invalid collected amount");
         assertCollectable(user, 0);
@@ -610,7 +610,7 @@ abstract contract DripsHubUserUtils is DSTest {
     }
 
     function collectable(DripsHubUser user) internal view returns (uint128 amt) {
-        return user.collectable(address(user), defaultAsset);
+        return user.collectable(calcUserId(user), defaultAsset);
     }
 
     function assertCollectable(DripsHubUser user, uint256 expected) internal {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -550,7 +550,11 @@ abstract contract DripsHubUserUtils is DSTest {
         assertReceivableDrips(user, type(uint64).max, expectedTotalAmt, 0);
         assertReceivableDrips(user, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
-        (uint128 receivedAmt, uint64 receivableCycles) = user.receiveDrips(defaultAsset, maxCycles);
+        (uint128 receivedAmt, uint64 receivableCycles) = user.receiveDrips(
+            calcUserId(user),
+            defaultAsset,
+            maxCycles
+        );
 
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
         assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
@@ -569,7 +573,11 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 expectedAmt,
         uint64 expectedCycles
     ) internal {
-        (uint128 actualAmt, uint64 actualCycles) = user.receivableDrips(defaultAsset, maxCycles);
+        (uint128 actualAmt, uint64 actualCycles) = user.receivableDrips(
+            calcUserId(user),
+            defaultAsset,
+            maxCycles
+        );
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
         assertEq(actualCycles, expectedCycles, "Invalid receivable drips cycles");
     }

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -583,7 +583,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 collectableBefore = collectable(user);
 
         (uint128 collectableAmt, uint128 splitAmt) = user.split(
-            address(user),
+            calcUserId(user),
             defaultAsset,
             getCurrSplitsReceivers(user)
         );
@@ -595,7 +595,7 @@ abstract contract DripsHubUserUtils is DSTest {
     }
 
     function assertSplittable(DripsHubUser user, uint256 expected) internal {
-        assertEq(user.splittable(address(user), defaultAsset), expected, "Invalid splittable");
+        assertEq(user.splittable(calcUserId(user), defaultAsset), expected, "Invalid splittable");
     }
 
     function collect(DripsHubUser user, uint128 expectedAmt) internal {

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -559,7 +559,7 @@ abstract contract DripsHubUserUtils is DSTest {
     }
 
     function assertReceivableDripsCycles(DripsHubUser user, uint64 expectedCycles) internal {
-        uint64 actualCycles = user.receivableDripsCycles(defaultAsset);
+        uint64 actualCycles = user.receivableDripsCycles(calcUserId(user), defaultAsset);
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -469,6 +469,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint256 expectedBalance = user.balance(asset) + expectedCollected;
 
         (uint128 collectedAmt, uint128 splitAmt) = user.collectAll(
+            calcUserId(user),
             asset,
             getCurrSplitsReceivers(user)
         );
@@ -506,6 +507,7 @@ abstract contract DripsHubUserUtils is DSTest {
         uint128 expectedSplit
     ) internal {
         (uint128 actualCollected, uint128 actualSplit) = user.collectableAll(
+            calcUserId(user),
             asset,
             getCurrSplitsReceivers(user)
         );
@@ -515,7 +517,11 @@ abstract contract DripsHubUserUtils is DSTest {
 
     function totalCollectableAll(uint256 asset, DripsHubUser user) internal view returns (uint128) {
         SplitsReceiver[] memory splits = getCurrSplitsReceivers(user);
-        (uint128 collectableAmt, uint128 splittableAmt) = user.collectableAll(asset, splits);
+        (uint128 collectableAmt, uint128 splittableAmt) = user.collectableAll(
+            calcUserId(user),
+            asset,
+            splits
+        );
         return collectableAmt + splittableAmt;
     }
 

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -133,7 +133,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testCollectCanBePaused() public {
         admin.pause();
-        try admin.collect(defaultAsset) {
+        try admin.collect(calcUserId(admin), defaultAsset) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid collect revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -115,7 +115,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testReceiveDripsCanBePaused() public {
         admin.pause();
-        try admin.receiveDrips(defaultAsset, 1) {
+        try admin.receiveDrips(calcUserId(admin), defaultAsset, 1) {
             assertTrue(false, "ReceiveDrips hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid receiveDrips revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -124,7 +124,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testSplitCanBePaused() public {
         admin.pause();
-        try admin.split(address(admin), defaultAsset, new SplitsReceiver[](0)) {
+        try admin.split(calcUserId(admin), defaultAsset, new SplitsReceiver[](0)) {
             assertTrue(false, "Split hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid split revert reason");

--- a/src/test/ManagedDripsHub.t.sol
+++ b/src/test/ManagedDripsHub.t.sol
@@ -106,7 +106,7 @@ abstract contract ManagedDripsHubTest is DripsHubTest {
 
     function testCollectAllCanBePaused() public {
         admin.pause();
-        try admin.collectAll(defaultAsset, new SplitsReceiver[](0)) {
+        try admin.collectAll(calcUserId(user), defaultAsset, new SplitsReceiver[](0)) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, ERROR_PAUSED, "Invalid collect revert reason");


### PR DESCRIPTION
Closes https://github.com/radicle-dev/radicle-drips-hub/issues/98, blocked by https://github.com/radicle-dev/radicle-drips-hub/pull/114.

Switches the collecting functions identification from implicit msg.sender to user ID. This means that sub-accounts can collect.