### PR TITLE
Drop DripsHub from asset flow

### DIFF
--- a/src/AddressId.sol
+++ b/src/AddressId.sol
@@ -2,15 +2,18 @@
 pragma solidity ^0.8.7;
 
 import {DripsReceiver, ERC20DripsHub, SplitsReceiver} from "./ERC20DripsHub.sol";
+import {IERC20Reserve} from "./ERC20Reserve.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 contract AddressId {
     ERC20DripsHub public immutable dripsHub;
+    address public immutable reserve;
     uint32 public immutable accountId;
 
     /// @param _dripsHub The drips hub to use
     constructor(ERC20DripsHub _dripsHub) {
         dripsHub = _dripsHub;
+        reserve = address(_dripsHub.reserve());
         accountId = _dripsHub.createAccount(address(this));
     }
 
@@ -118,8 +121,8 @@ contract AddressId {
 
     function _transferFromCaller(IERC20 erc20, uint128 amt) internal {
         require(erc20.transferFrom(msg.sender, address(this), amt), "Transfer from caller failed");
-        if (erc20.allowance(address(this), address(dripsHub)) < amt) {
-            erc20.approve(address(dripsHub), type(uint256).max);
+        if (erc20.allowance(address(this), reserve) < amt) {
+            erc20.approve(reserve, type(uint256).max);
         }
     }
 

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -74,14 +74,9 @@ contract ERC20DripsHub is ManagedDripsHub {
     function _transfer(uint256 assetId, int128 amt) internal override {
         IERC20 erc20 = IERC20(address(uint160(assetId)));
         if (amt > 0) {
-            uint256 withdraw = uint128(amt);
-            reserve.withdraw(erc20, withdraw);
-            erc20.transfer(msg.sender, withdraw);
+            reserve.withdraw(erc20, msg.sender, uint128(amt));
         } else if (amt < 0) {
-            uint256 deposit = uint128(-amt);
-            erc20.transferFrom(msg.sender, address(this), deposit);
-            erc20.approve(address(reserve), deposit);
-            reserve.deposit(erc20, deposit);
+            reserve.deposit(erc20, msg.sender, uint128(-amt));
         }
     }
 }


### PR DESCRIPTION
This saves a `transfer` when moving tokens into or out of the drips contract. 