### PR TITLE
Accept IERC20 in DripsHub API

### DIFF
--- a/src/AddressId.sol
+++ b/src/AddressId.sol
@@ -35,11 +35,7 @@ contract AddressId {
         IERC20 erc20,
         SplitsReceiver[] memory currReceivers
     ) public returns (uint128 collectedAmt, uint128 splitAmt) {
-        (collectedAmt, splitAmt) = dripsHub.collectAll(
-            calcUserId(user),
-            _calcAssetId(erc20),
-            currReceivers
-        );
+        (collectedAmt, splitAmt) = dripsHub.collectAll(calcUserId(user), erc20, currReceivers);
         _transferTo(user, erc20, collectedAmt);
     }
 
@@ -48,7 +44,7 @@ contract AddressId {
     /// @param erc20 The token to use
     /// @return amt The collected amount
     function collect(address user, IERC20 erc20) public returns (uint128 amt) {
-        amt = dripsHub.collect(calcUserId(user), _calcAssetId(erc20));
+        amt = dripsHub.collect(calcUserId(user), erc20);
         _transferTo(user, erc20, amt);
     }
 
@@ -64,7 +60,7 @@ contract AddressId {
         uint128 amt
     ) public {
         _transferFromCaller(erc20, amt);
-        dripsHub.give(calcUserId(msg.sender), receiver, _calcAssetId(erc20), amt);
+        dripsHub.give(calcUserId(msg.sender), receiver, erc20, amt);
     }
 
     /// @notice Sets the msg.sender's drips configuration.
@@ -96,7 +92,7 @@ contract AddressId {
         if (balanceDelta > 0) _transferFromCaller(erc20, uint128(balanceDelta));
         (newBalance, realBalanceDelta) = dripsHub.setDrips(
             calcUserId(msg.sender),
-            _calcAssetId(erc20),
+            erc20,
             lastUpdate,
             lastBalance,
             currReceivers,
@@ -113,10 +109,6 @@ contract AddressId {
     /// share of the funds collected by the user.
     function setSplits(SplitsReceiver[] memory receivers) public {
         dripsHub.setSplits(calcUserId(msg.sender), receivers);
-    }
-
-    function _calcAssetId(IERC20 erc20) internal pure returns (uint256) {
-        return uint160(address(erc20));
     }
 
     function _transferFromCaller(IERC20 erc20, uint128 amt) internal {

--- a/src/test/AddressIdUser.t.sol
+++ b/src/test/AddressIdUser.t.sol
@@ -15,19 +15,14 @@ contract AddressIdUser {
         userId = addressId_.calcUserId(address(this));
     }
 
-    function balance(uint256 assetId) public view returns (uint256) {
-        return _erc20(assetId).balanceOf(address(this));
-    }
-
     function setDrips(
-        uint256 assetId,
+        IERC20 erc20,
         uint64 lastUpdate,
         uint128 lastBalance,
         DripsReceiver[] calldata currReceivers,
         int128 balanceDelta,
         DripsReceiver[] calldata newReceivers
     ) public returns (uint128 newBalance, int128 realBalanceDelta) {
-        IERC20 erc20 = _erc20(assetId);
         if (balanceDelta > 0) erc20.approve(address(addressId), uint128(balanceDelta));
         return
             addressId.setDrips(
@@ -42,10 +37,9 @@ contract AddressIdUser {
 
     function give(
         uint256 receiver,
-        uint256 assetId,
+        IERC20 erc20,
         uint128 amt
     ) public {
-        IERC20 erc20 = _erc20(assetId);
         erc20.approve(address(addressId), amt);
         addressId.give(receiver, erc20, amt);
     }
@@ -56,17 +50,13 @@ contract AddressIdUser {
 
     function collectAll(
         address user,
-        uint256 assetId,
+        IERC20 erc20,
         SplitsReceiver[] calldata currReceivers
     ) public returns (uint128 collected, uint128 splitAmt) {
-        return addressId.collectAll(user, _erc20(assetId), currReceivers);
+        return addressId.collectAll(user, erc20, currReceivers);
     }
 
-    function collect(address user, uint256 assetId) public returns (uint128 amt) {
-        return addressId.collect(user, _erc20(assetId));
-    }
-
-    function _erc20(uint256 assetId) internal pure returns (IERC20) {
-        return IERC20(address(uint160(assetId)));
+    function collect(address user, IERC20 erc20) public returns (uint128 amt) {
+        return addressId.collect(user, erc20);
     }
 }


### PR DESCRIPTION
Blocked by #125 

Switches DripsHub API from requiring leakingly abstract assetIDs to plain IERC20 addresses.