### PR TITLE
test: migrate splits tests to only test the library

### DIFF
--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -212,7 +212,7 @@ library Splits {
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-    function setSplits(
+   function setSplits(
         Storage storage s,
         uint256 userId,
         SplitsReceiver[] memory receivers
@@ -225,7 +225,6 @@ library Splits {
         }
         emit SplitsSet(userId, newSplitsHash);
     }
-
     /// @notice Validates a list of splits receivers and emits events for them
     /// @param receivers The list of splits receivers
     /// @param receiversHash The hash of the list of splits receivers.

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -212,7 +212,7 @@ library Splits {
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
     /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
     /// share of the funds collected by the user.
-   function setSplits(
+    function setSplits(
         Storage storage s,
         uint256 userId,
         SplitsReceiver[] memory receivers
@@ -225,6 +225,7 @@ library Splits {
         }
         emit SplitsSet(userId, newSplitsHash);
     }
+
     /// @notice Validates a list of splits receivers and emits events for them
     /// @param receivers The list of splits receivers
     /// @param receiversHash The hash of the list of splits receivers.

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -485,4 +485,38 @@ contract DripsHubTest is DripsHubUserUtils {
             assertEq(reason, ERROR_PAUSED, "Invalid createAccount revert reason");
         }
     }
+
+    function testCollectAllSplitsFundsFromSplits() public {
+        uint32 totalWeight = dripsHub.totalSplitsWeight();
+        setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
+        setSplits(receiver1, splitsReceivers(receiver2, totalWeight));
+        setSplits(receiver2, splitsReceivers(receiver3, totalWeight));
+        warpToCycleEnd();
+        assertCollectableAll(receiver2, 0);
+        assertCollectableAll(receiver3, 0);
+        // Receiver1 had 1 second paying 10 per second of which 10 is split
+        collectAll(receiver1, 0, 10);
+        // Receiver2 got 10 split from receiver1 of which 10 is split
+        collectAll(receiver2, 0, 10);
+        // Receiver3 got 10 split from receiver2
+        collectAll(receiver3, 10);
+    }
+
+    function testCollectAllSplitsFundsBetweenReceiverAndSplits() public {
+        uint32 totalWeight = dripsHub.totalSplitsWeight();
+        setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
+        setSplits(
+            receiver1,
+            splitsReceivers(receiver2, totalWeight / 4, receiver3, totalWeight / 2)
+        );
+        warpToCycleEnd();
+        assertCollectableAll(receiver2, 0);
+        assertCollectableAll(receiver3, 0);
+        // Receiver1 had 1 second paying 10 per second, of which 3/4 is split, which is 7
+        collectAll(receiver1, 3, 7);
+        // Receiver2 got 1/3 of 7 split from receiver1, which is 2
+        collectAll(receiver2, 2);
+        // Receiver3 got 2/3 of 7 split from receiver1, which is 5
+        collectAll(receiver3, 5);
+    }
 }

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -89,54 +89,6 @@ contract DripsHubTest is DripsHubUserUtils {
         }
     }
 
-    function testLimitsTheTotalSplitsReceiversCount() public {
-        uint160 countMax = dripsHub.maxSplitsReceivers();
-        SplitsReceiver[] memory receiversGood = new SplitsReceiver[](countMax);
-        SplitsReceiver[] memory receiversBad = new SplitsReceiver[](countMax + 1);
-        for (uint160 i = 0; i < countMax; i++) {
-            receiversGood[i] = SplitsReceiver(i, 1);
-            receiversBad[i] = receiversGood[i];
-        }
-        receiversBad[countMax] = SplitsReceiver(countMax, 1);
-
-        setSplits(user, receiversGood);
-        assertSetSplitsReverts(user, receiversBad, "Too many splits receivers");
-    }
-
-    function testRejectsTooHighTotalWeightSplitsReceivers() public {
-        uint32 totalWeight = dripsHub.totalSplitsWeight();
-        setSplits(user, splitsReceivers(receiver, totalWeight));
-        assertSetSplitsReverts(
-            user,
-            splitsReceivers(receiver, totalWeight + 1),
-            "Splits weights sum too high"
-        );
-    }
-
-    function testRejectsZeroWeightSplitsReceivers() public {
-        assertSetSplitsReverts(
-            user,
-            splitsReceivers(receiver, 0),
-            "Splits receiver weight is zero"
-        );
-    }
-
-    function testRejectsUnsortedSplitsReceivers() public {
-        assertSetSplitsReverts(
-            user,
-            splitsReceivers(receiver2, 1, receiver1, 1),
-            "Splits receivers not sorted by user ID"
-        );
-    }
-
-    function testRejectsDuplicateSplitsReceivers() public {
-        assertSetSplitsReverts(
-            user,
-            splitsReceivers(receiver, 1, receiver, 2),
-            "Duplicate splits receivers"
-        );
-    }
-
     function testCollectAllSplits() public {
         uint32 totalWeight = dripsHub.totalSplitsWeight();
         setDrips(user, 0, 10, dripsReceivers(receiver1, 10));
@@ -209,22 +161,6 @@ contract DripsHubTest is DripsHubUserUtils {
         collectAll(receiver2, 2);
         // Receiver3 got 2/3 of 7 split from receiver1, which is 5
         collectAll(receiver3, 5);
-    }
-
-    function testCanSplitAllWhenCollectedDoesntSplitEvenly() public {
-        uint32 totalWeight = dripsHub.totalSplitsWeight();
-        setDrips(user, 0, 3, dripsReceivers(receiver1, 3));
-        setSplits(
-            receiver1,
-            splitsReceivers(receiver2, totalWeight / 2, receiver3, totalWeight / 2)
-        );
-        warpToCycleEnd();
-        // Receiver1 had 1 second paying 3 per second of which 3 is split
-        collectAll(receiver1, 0, 3);
-        // Receiver2 got 1 split from receiver
-        collectAll(receiver2, 1);
-        // Receiver3 got 2 split from receiver
-        collectAll(receiver3, 2);
     }
 
     function testReceiveSomeDripsCycles() public {

--- a/src/test/Splits.t.sol
+++ b/src/test/Splits.t.sol
@@ -16,7 +16,6 @@ contract SplitsTest is DSTest {
     uint256 internal receiver1 = 5;
     uint256 internal receiver2 = 6;
     uint256 internal receiver3 = 7;
-    uint256 internal receiver4 = 8;
     uint256 internal user = 9;
 
     function splitsReceivers() internal pure returns (SplitsReceiver[] memory list) {

--- a/src/test/Splits.t.sol
+++ b/src/test/Splits.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.13;
+
+import {DSTest} from "ds-test/test.sol";
+import {Hevm} from "./Hevm.t.sol";
+import {Splits, SplitsReceiver} from "../Splits.sol";
+
+contract SplitsTest is DSTest {
+    Splits.Storage internal s;
+    // Keys is user ID
+    mapping(uint256 => SplitsReceiver[]) internal currSplitsReceivers;
+
+    uint256 internal defaultAsset = 1;
+    uint256 internal otherAsset = 2;
+    uint256 internal receiver = 4;
+    uint256 internal receiver1 = 5;
+    uint256 internal receiver2 = 6;
+    uint256 internal receiver3 = 7;
+    uint256 internal receiver4 = 8;
+    uint256 internal user = 9;
+
+    function splitsReceivers() internal pure returns (SplitsReceiver[] memory list) {
+        list = new SplitsReceiver[](0);
+    }
+
+    function splitsReceivers(uint256 userId, uint32 weight)
+        internal
+        pure
+        returns (SplitsReceiver[] memory list)
+    {
+        list = new SplitsReceiver[](1);
+        list[0] = SplitsReceiver(userId, weight);
+    }
+
+    function splitsReceivers(
+        uint256 user1,
+        uint32 weight1,
+        uint256 user2,
+        uint32 weight2
+    ) internal pure returns (SplitsReceiver[] memory list) {
+        list = new SplitsReceiver[](2);
+        list[0] = SplitsReceiver(user1, weight1);
+        list[1] = SplitsReceiver(user2, weight2);
+    }
+
+    function getCurrSplitsReceivers(uint256 userId)
+        internal
+        returns (SplitsReceiver[] memory currSplits)
+    {
+        currSplits = currSplitsReceivers[userId];
+
+        Splits.assertCurrSplits(s, userId, currSplits);
+    }
+
+    function setSplitsExternal(uint256 userId, SplitsReceiver[] memory newReceivers) external {
+        Splits.setSplits(s, userId, newReceivers);
+    }
+
+    function assertSetSplitsReverts(
+        uint256 userId,
+        SplitsReceiver[] memory newReceivers,
+        string memory expectedReason
+    ) internal {
+        SplitsReceiver[] memory curr = getCurrSplitsReceivers(userId);
+        Splits.assertCurrSplits(s, userId, curr);
+        try this.setSplitsExternal(userId, newReceivers) {
+            assertTrue(false, "setSplits hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, expectedReason, "Invalid setSplits revert reason");
+        }
+    }
+
+    function assertSplits(uint256 userId, SplitsReceiver[] memory expectedReceivers) internal view {
+        Splits.assertCurrSplits(s, userId, expectedReceivers);
+    }
+
+    function assertSplittable(uint256 userId, uint256 expected) internal {
+        uint256 actual = Splits.splittable(s, userId, defaultAsset);
+        assertEq(actual, expected, "Invalid splittable");
+    }
+
+    function setSplits(uint256 userId, SplitsReceiver[] memory newReceivers) internal {
+        SplitsReceiver[] memory curr = getCurrSplitsReceivers(userId);
+        assertSplits(userId, curr);
+
+        Splits.setSplits(s, userId, newReceivers);
+
+        setCurrSplitsReceivers(userId, newReceivers);
+    }
+
+    function setCurrSplitsReceivers(uint256 userId, SplitsReceiver[] memory newReceivers) internal {
+        assertSplits(userId, newReceivers);
+        delete currSplitsReceivers[userId];
+        for (uint256 i = 0; i < newReceivers.length; i++) {
+            currSplitsReceivers[userId].push(newReceivers[i]);
+        }
+    }
+
+    function split(
+        uint256 userId,
+        uint128 expectedCollectable,
+        uint128 expectedSplit
+    ) internal {
+        (uint128 collectableAmt, uint128 splitAmt) = Splits.split(
+            s,
+            userId,
+            defaultAsset,
+            getCurrSplitsReceivers(userId)
+        );
+
+        assertEq(collectableAmt, expectedCollectable, "Invalid collectable amount");
+        assertEq(splitAmt, expectedSplit, "Invalid split amount");
+        assertSplittable(userId, 0);
+    }
+
+    // test cases
+    function testSplitable() public {
+        uint128 amt = 10;
+        Splits.give(s, 0, user, defaultAsset, amt);
+        assertSplittable(user, amt);
+    }
+
+    function testSimpleSplit() public {
+        // 60% split
+        setSplits(user, splitsReceivers(receiver, (Splits.TOTAL_SPLITS_WEIGHT / 10) * 6));
+        uint128 amt = 10;
+        Splits.give(s, 0, user, defaultAsset, amt);
+        assertSplittable(user, amt);
+
+        uint128 expectedCollectable = 4;
+        uint128 expectedSplit = 6;
+        split(user, expectedCollectable, expectedSplit);
+    }
+
+    function testLimitsTheTotalSplitsReceiversCount() public {
+        uint160 countMax = Splits.MAX_SPLITS_RECEIVERS;
+        SplitsReceiver[] memory receiversGood = new SplitsReceiver[](countMax);
+        SplitsReceiver[] memory receiversBad = new SplitsReceiver[](countMax + 1);
+        for (uint160 i = 0; i < countMax; i++) {
+            receiversGood[i] = SplitsReceiver(i, 1);
+            receiversBad[i] = receiversGood[i];
+        }
+        receiversBad[countMax] = SplitsReceiver(countMax, 1);
+
+        setSplits(user, receiversGood);
+        assertSetSplitsReverts(user, receiversBad, "Too many splits receivers");
+    }
+
+    function testRejectsTooHighTotalWeightSplitsReceivers() public {
+        uint32 totalWeight = Splits.TOTAL_SPLITS_WEIGHT;
+        setSplits(user, splitsReceivers(receiver, totalWeight));
+        assertSetSplitsReverts(
+            user,
+            splitsReceivers(receiver, totalWeight + 1),
+            "Splits weights sum too high"
+        );
+    }
+
+    function testRejectsZeroWeightSplitsReceivers() public {
+        assertSetSplitsReverts(
+            user,
+            splitsReceivers(receiver, 0),
+            "Splits receiver weight is zero"
+        );
+    }
+
+    function testRejectsUnsortedSplitsReceivers() public {
+        assertSetSplitsReverts(
+            user,
+            splitsReceivers(receiver2, 1, receiver1, 1),
+            "Splits receivers not sorted by user ID"
+        );
+    }
+
+    function testRejectsDuplicateSplitsReceivers() public {
+        assertSetSplitsReverts(
+            user,
+            splitsReceivers(receiver, 1, receiver, 2),
+            "Duplicate splits receivers"
+        );
+    }
+
+    function testCanSplitAllWhenCollectedDoesntSplitEvenly() public {
+        uint32 totalWeight = Splits.TOTAL_SPLITS_WEIGHT;
+        // 3 waiting for receiver 1
+        Splits.give(s, user, receiver1, defaultAsset, 3);
+
+        setSplits(
+            receiver1,
+            splitsReceivers(receiver2, totalWeight / 2, receiver3, totalWeight / 2)
+        );
+
+        // Receiver1 received 3 which 100% is split
+        split(receiver1, 0, 3);
+        // Receiver2 got 1 split from receiver
+        split(receiver2, 1, 0);
+        // Receiver3 got 2 split from receiver
+        split(receiver3, 2, 0);
+    }
+}

--- a/src/test/Splits.t.sol
+++ b/src/test/Splits.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {DSTest} from "ds-test/test.sol";
-import {Hevm} from "./Hevm.t.sol";
 import {Splits, SplitsReceiver} from "../Splits.sol";
 
 contract SplitsTest is DSTest {
@@ -320,7 +319,7 @@ contract SplitsTest is DSTest {
         splitCollect(otherAsset, receiver1, 10, 0);
     }
 
-    function testCollectAllSplitsFundsFromSplits() public {
+    function testForwardSplits() public {
         uint32 totalWeight = Splits.TOTAL_SPLITS_WEIGHT;
 
         give(user, receiver1, 10);
@@ -337,7 +336,7 @@ contract SplitsTest is DSTest {
         splitCollect(receiver3, 10, 0);
     }
 
-    function testCollectAllSplitsFundsBetweenReceiverAndSplits() public {
+    function testSplitMultipleReceivers() public {
         uint32 totalWeight = Splits.TOTAL_SPLITS_WEIGHT;
         give(user, receiver1, 10);
 

--- a/src/test/Splits.t.sol
+++ b/src/test/Splits.t.sol
@@ -347,7 +347,7 @@ contract SplitsTest is DSTest {
         );
         assertSplittable(receiver2, 0);
         assertSplittable(receiver3, 0);
-        // Receiver1 received 10 with a gi, of which 3/4 is split, which is 7
+        // Receiver1 received 10 with a give, of which 3/4 is split, which is 7
         splitCollect(receiver1, 3, 7);
         // Receiver2 got 1/3 of 7 split from receiver1, which is 2
         splitCollect(receiver2, 2, 0);


### PR DESCRIPTION
I migrated the splits tests from `DripsHub.t.sol` which only tests the Split library.

I modified some of them and changed the initial supply to a `give` instead of  `drip` if the test covers more split specific setups.

