### PR TITLE
Remove drips artificial max timestamp

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -95,6 +95,7 @@ contract DripsHub is Managed {
     /// High value makes collecting cheaper by making it process less cycles for a given time range.
     /// @param _reserve The address of the ERC-20 reserve which the drips hub will work with
     constructor(uint64 _cycleSecs, IReserve _reserve) {
+        require(_cycleSecs > 1, "Cycle length too low");
         cycleSecs = _cycleSecs;
         maxDripsReceivers = Drips.MAX_DRIPS_RECEIVERS;
         maxSplitsReceivers = Splits.MAX_SPLITS_RECEIVERS;

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -532,7 +532,7 @@ contract DripsTest is DSTest {
     }
 
     function testAllowsDrippingWithDurationEndingAfterMaxTimestamp() public {
-        uint64 maxTimestamp = Drips.MAX_TIMESTAMP;
+        uint64 maxTimestamp = type(uint64).max;
         uint64 currTimestamp = uint64(block.timestamp);
         uint64 maxDuration = maxTimestamp - currTimestamp;
         uint64 duration = maxDuration + 5;


### PR DESCRIPTION
In the current code the max timestamp was lower than `type(uint64).max` only to cover an absurd edge case of cycle length of 1 second.