### PR TITLE
Store the default drips end on-chain

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -49,7 +49,7 @@ contract DripsHub is Managed {
     IReserve public immutable reserve;
     /// @notice On every timestamp `T`, which is a multiple of `cycleSecs`, the receivers
     /// gain access to drips collected during `T - cycleSecs` to `T - 1`.
-    uint64 public immutable cycleSecs;
+    uint32 public immutable cycleSecs;
     /// @notice Maximum number of drips receivers of a single user.
     /// Limits cost of changes in drips configuration.
     uint32 public immutable maxDripsReceivers;
@@ -94,7 +94,7 @@ contract DripsHub is Managed {
     /// between being taken from the users' drips balances and being collectable by their receivers.
     /// High value makes collecting cheaper by making it process less cycles for a given time range.
     /// @param _reserve The address of the ERC-20 reserve which the drips hub will work with
-    constructor(uint64 _cycleSecs, IReserve _reserve) {
+    constructor(uint32 _cycleSecs, IReserve _reserve) {
         require(_cycleSecs > 1, "Cycle length too low");
         cycleSecs = _cycleSecs;
         maxDripsReceivers = Drips.MAX_DRIPS_RECEIVERS;
@@ -168,7 +168,7 @@ contract DripsHub is Managed {
             cycleSecs,
             userId,
             assetId,
-            type(uint64).max
+            type(uint32).max
         );
         // Collectable independently from cycles
         collectedAmt += Splits.splittable(_dripsHubStorage().splits, userId, assetId);
@@ -195,7 +195,7 @@ contract DripsHub is Managed {
         IERC20 erc20,
         SplitsReceiver[] memory currReceivers
     ) public whenNotPaused returns (uint128 collectedAmt, uint128 splitAmt) {
-        receiveDrips(userId, erc20, type(uint64).max);
+        receiveDrips(userId, erc20, type(uint32).max);
         (, splitAmt) = split(userId, erc20, currReceivers);
         collectedAmt = collect(userId, erc20);
     }
@@ -209,7 +209,7 @@ contract DripsHub is Managed {
     function receivableDripsCycles(uint256 userId, IERC20 erc20)
         public
         view
-        returns (uint64 cycles)
+        returns (uint32 cycles)
     {
         return
             Drips.receivableDripsCycles(
@@ -231,8 +231,8 @@ contract DripsHub is Managed {
     function receivableDrips(
         uint256 userId,
         IERC20 erc20,
-        uint64 maxCycles
-    ) public view returns (uint128 receivableAmt, uint64 receivableCycles) {
+        uint32 maxCycles
+    ) public view returns (uint128 receivableAmt, uint32 receivableCycles) {
         return
             Drips.receivableDrips(
                 _dripsHubStorage().drips,
@@ -256,8 +256,8 @@ contract DripsHub is Managed {
     function receiveDrips(
         uint256 userId,
         IERC20 erc20,
-        uint64 maxCycles
-    ) public whenNotPaused returns (uint128 receivedAmt, uint64 receivableCycles) {
+        uint32 maxCycles
+    ) public whenNotPaused returns (uint128 receivedAmt, uint32 receivableCycles) {
         uint256 assetId = _assetId(erc20);
         (receivedAmt, receivableCycles) = Drips.receiveDrips(
             _dripsHubStorage().drips,
@@ -345,7 +345,7 @@ contract DripsHub is Managed {
         view
         returns (
             bytes32 dripsHash,
-            uint64 updateTime,
+            uint32 updateTime,
             uint128 balance
         )
     {

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -11,7 +11,7 @@ contract DripsTest is DSTest {
     string internal constant ERROR_BALANCE = "Insufficient balance";
 
     Drips.Storage internal s;
-    uint64 internal cycleSecs = 10;
+    uint32 internal cycleSecs = 10;
     // Keys are assetId and userId
     mapping(uint256 => mapping(uint256 => DripsReceiver[])) internal currReceiversStore;
     uint256 internal defaultAsset = 1;
@@ -76,7 +76,7 @@ contract DripsTest is DSTest {
         uint256 duration
     ) internal pure returns (DripsReceiver[] memory receivers) {
         receivers = new DripsReceiver[](1);
-        receivers[0] = DripsReceiver(userId, uint128(amtPerSec), uint64(start), uint64(duration));
+        receivers[0] = DripsReceiver(userId, uint128(amtPerSec), uint32(start), uint32(duration));
     }
 
     function recv(DripsReceiver[] memory recv1, DripsReceiver[] memory recv2)
@@ -135,7 +135,7 @@ contract DripsTest is DSTest {
 
         storeCurrReceivers(assetId, userId, newReceivers);
         assertEq(newBalance, balanceTo, "Invalid drips balance");
-        (, uint64 updateTime, uint128 actualBalance) = Drips.dripsState(s, userId, assetId);
+        (, uint32 updateTime, uint128 actualBalance) = Drips.dripsState(s, userId, assetId);
         assertEq(updateTime, block.timestamp, "Invalid new last update time");
         assertEq(balanceTo, actualBalance, "Invalid drips balance");
         assertEq(realBalanceDelta, balanceDelta, "Invalid real balance delta");
@@ -222,25 +222,25 @@ contract DripsTest is DSTest {
         uint256 userId,
         uint128 expectedAmt
     ) internal {
-        (uint128 actualAmt, ) = Drips.receiveDrips(s, cycleSecs, userId, assetId, type(uint64).max);
+        (uint128 actualAmt, ) = Drips.receiveDrips(s, cycleSecs, userId, assetId, type(uint32).max);
         assertEq(actualAmt, expectedAmt, "Invalid amount received from drips");
     }
 
     function receiveDrips(
         uint256 userId,
-        uint64 maxCycles,
+        uint32 maxCycles,
         uint128 expectedReceivedAmt,
-        uint64 expectedReceivedCycles,
+        uint32 expectedReceivedCycles,
         uint128 expectedAmtAfter,
-        uint64 expectedCyclesAfter
+        uint32 expectedCyclesAfter
     ) internal {
         uint128 expectedTotalAmt = expectedReceivedAmt + expectedAmtAfter;
-        uint64 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
+        uint32 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
         assertReceivableDripsCycles(userId, expectedTotalCycles);
-        assertReceivableDrips(userId, type(uint64).max, expectedTotalAmt, 0);
+        assertReceivableDrips(userId, type(uint32).max, expectedTotalAmt, 0);
         assertReceivableDrips(userId, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
-        (uint128 receivedAmt, uint64 receivableCycles) = Drips.receiveDrips(
+        (uint128 receivedAmt, uint32 receivableCycles) = Drips.receiveDrips(
             s,
             cycleSecs,
             userId,
@@ -251,11 +251,11 @@ contract DripsTest is DSTest {
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
         assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(userId, expectedCyclesAfter);
-        assertReceivableDrips(userId, type(uint64).max, expectedAmtAfter, 0);
+        assertReceivableDrips(userId, type(uint32).max, expectedAmtAfter, 0);
     }
 
-    function assertReceivableDripsCycles(uint256 userId, uint64 expectedCycles) internal {
-        uint64 actualCycles = Drips.receivableDripsCycles(s, cycleSecs, userId, defaultAsset);
+    function assertReceivableDripsCycles(uint256 userId, uint32 expectedCycles) internal {
+        uint32 actualCycles = Drips.receivableDripsCycles(s, cycleSecs, userId, defaultAsset);
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 
@@ -265,18 +265,18 @@ contract DripsTest is DSTest {
             cycleSecs,
             userId,
             defaultAsset,
-            type(uint64).max
+            type(uint32).max
         );
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
     }
 
     function assertReceivableDrips(
         uint256 userId,
-        uint64 maxCycles,
+        uint32 maxCycles,
         uint128 expectedAmt,
-        uint64 expectedCycles
+        uint32 expectedCycles
     ) internal {
-        (uint128 actualAmt, uint64 actualCycles) = Drips.receivableDrips(
+        (uint128 actualAmt, uint32 actualCycles) = Drips.receivableDrips(
             s,
             cycleSecs,
             userId,
@@ -521,7 +521,7 @@ contract DripsTest is DSTest {
     }
 
     function testAllowsDrippingWhichShouldEndAfterMaxTimestamp() public {
-        uint128 balance = type(uint64).max + uint128(6);
+        uint128 balance = type(uint32).max + uint128(6);
         setDrips(sender, 0, balance, recv(receiver, 1));
         warpBy(10);
         // Sender had 10 seconds paying 1 per second
@@ -532,10 +532,10 @@ contract DripsTest is DSTest {
     }
 
     function testAllowsDrippingWithDurationEndingAfterMaxTimestamp() public {
-        uint64 maxTimestamp = type(uint64).max;
-        uint64 currTimestamp = uint64(block.timestamp);
-        uint64 maxDuration = maxTimestamp - currTimestamp;
-        uint64 duration = maxDuration + 5;
+        uint32 maxTimestamp = type(uint32).max;
+        uint32 currTimestamp = uint32(block.timestamp);
+        uint32 maxDuration = maxTimestamp - currTimestamp;
+        uint32 duration = maxDuration + 5;
         setDrips(sender, 0, duration, recv(receiver, 1, 0, duration));
         warpToCycleEnd();
         receiveDrips(receiver, cycleSecs);

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -237,7 +237,7 @@ contract DripsHubTest is DripsHubUserUtils {
     }
 
     function testDripsInDifferentTokensAreIndependent() public {
-        uint64 cycleLength = dripsHub.cycleSecs();
+        uint32 cycleLength = dripsHub.cycleSecs();
         // Covers 1.5 cycles of dripping
         setDrips(
             defaultErc20,
@@ -349,7 +349,7 @@ contract DripsHubTest is DripsHubUserUtils {
     }
 
     function testContractCanBeUpgraded() public {
-        uint64 newCycleLength = dripsHub.cycleSecs() + 1;
+        uint32 newCycleLength = dripsHub.cycleSecs() + 1;
         DripsHub newLogic = new DripsHub(newCycleLength, dripsHub.reserve());
         admin.upgradeTo(address(newLogic));
         assertEq(dripsHub.cycleSecs(), newCycleLength, "Invalid new cycle length");

--- a/src/test/DripsHubUserUtils.t.sol
+++ b/src/test/DripsHubUserUtils.t.sol
@@ -128,7 +128,7 @@ abstract contract DripsHubUserUtils is DSTest {
         storeDrips(erc20, user, newReceivers);
         assertEq(newBalance, balanceTo, "Invalid drips balance");
         assertEq(realBalanceDelta, balanceDelta, "Invalid real balance delta");
-        (, uint64 updateTime, uint128 actualBalance) = dripsHub.dripsState(user.userId(), erc20);
+        (, uint32 updateTime, uint128 actualBalance) = dripsHub.dripsState(user.userId(), erc20);
         assertEq(updateTime, block.timestamp, "Invalid new last update time");
         assertEq(balanceTo, actualBalance, "Invalid drips balance");
         assertEq(balanceTo, actualBalance, "Invalid drips balance");
@@ -354,26 +354,26 @@ abstract contract DripsHubUserUtils is DSTest {
     function receiveDrips(
         AddressIdUser user,
         uint128 expectedReceivedAmt,
-        uint64 expectedReceivedCycles
+        uint32 expectedReceivedCycles
     ) internal {
-        receiveDrips(user, type(uint64).max, expectedReceivedAmt, expectedReceivedCycles, 0, 0);
+        receiveDrips(user, type(uint32).max, expectedReceivedAmt, expectedReceivedCycles, 0, 0);
     }
 
     function receiveDrips(
         AddressIdUser user,
-        uint64 maxCycles,
+        uint32 maxCycles,
         uint128 expectedReceivedAmt,
-        uint64 expectedReceivedCycles,
+        uint32 expectedReceivedCycles,
         uint128 expectedAmtAfter,
-        uint64 expectedCyclesAfter
+        uint32 expectedCyclesAfter
     ) internal {
         uint128 expectedTotalAmt = expectedReceivedAmt + expectedAmtAfter;
-        uint64 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
+        uint32 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
         assertReceivableDripsCycles(user, expectedTotalCycles);
-        assertReceivableDrips(user, type(uint64).max, expectedTotalAmt, 0);
+        assertReceivableDrips(user, type(uint32).max, expectedTotalAmt, 0);
         assertReceivableDrips(user, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
-        (uint128 receivedAmt, uint64 receivableCycles) = dripsHub.receiveDrips(
+        (uint128 receivedAmt, uint32 receivableCycles) = dripsHub.receiveDrips(
             user.userId(),
             defaultErc20,
             maxCycles
@@ -382,21 +382,21 @@ abstract contract DripsHubUserUtils is DSTest {
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
         assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(user, expectedCyclesAfter);
-        assertReceivableDrips(user, type(uint64).max, expectedAmtAfter, 0);
+        assertReceivableDrips(user, type(uint32).max, expectedAmtAfter, 0);
     }
 
-    function assertReceivableDripsCycles(AddressIdUser user, uint64 expectedCycles) internal {
-        uint64 actualCycles = dripsHub.receivableDripsCycles(user.userId(), defaultErc20);
+    function assertReceivableDripsCycles(AddressIdUser user, uint32 expectedCycles) internal {
+        uint32 actualCycles = dripsHub.receivableDripsCycles(user.userId(), defaultErc20);
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 
     function assertReceivableDrips(
         AddressIdUser user,
-        uint64 maxCycles,
+        uint32 maxCycles,
         uint128 expectedAmt,
-        uint64 expectedCycles
+        uint32 expectedCycles
     ) internal {
-        (uint128 actualAmt, uint64 actualCycles) = dripsHub.receivableDrips(
+        (uint128 actualAmt, uint32 actualCycles) = dripsHub.receivableDrips(
             user.userId(),
             defaultErc20,
             maxCycles


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-drips-hub/issues/128.

This PR reduces the maximum timestamp from uint64 to uint32 moving the death of drips protocol from year 584554532842 to mere 2106.  It allows storing on-chain the default drips end without using any additional slots.