### PR TITLE
Make transferAccount pausable

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -138,7 +138,7 @@ contract DripsHub is Managed {
     /// Must be called by the current account owner.
     /// @param accountId The account which ownership is transferred
     /// @param newOwner The new account owner
-    function transferAccount(uint32 accountId, address newOwner) public {
+    function transferAccount(uint32 accountId, address newOwner) public whenNotPaused {
         _assertCallerIsAccountOwner(accountId);
         _dripsHubStorage().accountsOwners[accountId] = newOwner;
         emit AccountTransferred(accountId, msg.sender, newOwner);


### PR DESCRIPTION
Also moves 2 `collectAll` tests back to the place where similar tests are to make it easier to find them.